### PR TITLE
base TCR container support

### DIFF
--- a/container/dandelion_preprocess.py
+++ b/container/dandelion_preprocess.py
@@ -65,7 +65,7 @@ def main():
 	#no tricks here
 	ddl.pp.reannotate_genes(samples, loci=args.chain, filename_prefix = args.file_prefix)
 	
-	#IG requires further preprocessing, TR is largely done now
+	#IG requires further preprocessing, TR is done now
 	if args.chain == 'ig':
 		#STEP THREE - ddl.pp.reassign_alleles()
 		#do we have individual information
@@ -87,13 +87,11 @@ def main():
 		#STEP FOUR - ddl.pp.assign_isotypes()
 		#also no tricks here
 		ddl.pp.assign_isotypes(samples, save_plot=True, filename_prefix = args.file_prefix)
-	else:
-		#TODO: copy over the TR output file
 	
 	#at this stage it's safe to remove the per-sample dandelion/data/tmp folder if need be
 	if args.clean_output:
 		for sample in samples:
-			os.system('rm -rf '+sample+'/dandelion/data/tmp')
+			os.system('rm -rf '+sample+'/dandelion/tmp')
 
 if __name__ == "__main__":
 	main()

--- a/container/dandelion_preprocess.py
+++ b/container/dandelion_preprocess.py
@@ -12,10 +12,16 @@ def parse_args():
 	'''
 	parser = argparse.ArgumentParser()
 	parser.add_argument('--meta', help='Optional metadata CSV file, header required, first column for sample ID matching folder names in the directory this is being ran in. Can have a "prefix"/"suffix" column for barcode alteration, and "individual" to provide tigger groupings that isn\'t analysing all of the samples jointly.')
-	parser.add_argument('--sep', type=str, default="_", help='The separator to place between the barcode and prefix/suffix. Defaults to "_". Uses sample names as a prefix if metadata CSV file absent and more than one sample to process.')
+	parser.add_argument('--chain', type=str, default="IG", help='Whether the data is TR or IG, as the  preprocessing pipelines differ. Defaults to "IG".')
+	parser.add_argument('--file_prefix', type=str, default="filtered", help='Which set of contig files to take for the folder. For a given PREFIX, will use PREFIX_contig_annotations.csv and PREFIX_contig.fasta. Defaults to "filtered".')
+	parser.add_argument('--sep', type=str, default="_", help='The separator to place between the barcode and prefix/suffix. Uses sample names as a prefix for BCR data if metadata CSV file absent and more than one sample to process. Defaults to "_".')
 	parser.add_argument('--keep_trailing_hyphen_number', action='store_false', help='If passed, do not strip out the trailing hyphen number, e.g. "-1", from the end of barcodes.')
 	parser.add_argument('--clean_output', action='store_true', help='If passed, remove intermediate files that aren\'t the primary output from the run reults. The intermediate files may be occasionally useful for inspection.')
 	args = parser.parse_args()
+	#convert loci to lower case for compatibility, and ensure it's in TR/IG
+	args.chain = args.chain.lower()
+	if args.chain not in ['tr', 'ig']:
+		raise ValueError('Chain must be TR or IG')
 	return args
 
 def main():
@@ -42,48 +48,52 @@ def main():
 	if 'prefix' in meta.columns:
 		#process with prefix
 		vals = list(meta['prefix'].values)
-		ddl.pp.format_fastas(samples, prefix=vals, sep=args.sep, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number)
+		ddl.pp.format_fastas(samples, prefix=vals, sep=args.sep, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number, filename_prefix = args.file_prefix)
 	elif 'suffix' in meta.columns:
 		#process with suffix
 		vals = list(meta['suffix'].values)
-		ddl.pp.format_fastas(samples, suffix=vals, sep=args.sep, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number)
+		ddl.pp.format_fastas(samples, suffix=vals, sep=args.sep, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number, filename_prefix = args.file_prefix)
 	else:
-		#neither. tag with the sample names as default, if more than one sample
-		if len(samples) > 1:
-			ddl.pp.format_fastas(samples, prefix=samples, sep=args.sep, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number)
+		#neither. tag with the sample names as default, if more than one sample and the data is IG
+		if len(samples) > 1 and args.chain == 'ig':
+			ddl.pp.format_fastas(samples, prefix=samples, sep=args.sep, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number, filename_prefix = args.file_prefix)
 		else:
 			#no need to tag as it's a single sample.
-			ddl.pp.format_fastas(samples, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number)
+			ddl.pp.format_fastas(samples, remove_trailing_hyphen_number=args.keep_trailing_hyphen_number, filename_prefix = args.file_prefix)
 	
 	#STEP TWO - ddl.pp.reannotate_genes()
 	#no tricks here
-	ddl.pp.reannotate_genes(samples)
+	ddl.pp.reannotate_genes(samples, loci=args.chain, filename_prefix = args.file_prefix)
 	
-	#STEP THREE - ddl.pp.reassign_alleles()
-	#do we have individual information
-	if 'individual' in meta.columns:
-		#run the function for each individual separately
-		for ind in np.unique(meta['individual']):
-			#yes, this screwy thing is needed so the function ingests it correctly, sorry
-			ddl.pp.reassign_alleles([str(i) for i in meta[meta['individual']==ind].index.values], combined_folder=ind, save_plot=True)
+	#IG requires further preprocessing, TR is largely done now
+	if args.chain == 'ig':
+		#STEP THREE - ddl.pp.reassign_alleles()
+		#do we have individual information
+		if 'individual' in meta.columns:
+			#run the function for each individual separately
+			for ind in np.unique(meta['individual']):
+				#yes, this screwy thing is needed so the function ingests it correctly, sorry
+				ddl.pp.reassign_alleles([str(i) for i in meta[meta['individual']==ind].index.values], combined_folder=ind, save_plot=True, filename_prefix = args.file_prefix)
+				#remove if cleaning output - the important information is ported to sample folders already
+				if args.clean_output:
+					os.system('rm -r '+ind)
+		else:
+			#run on the whole thing at once
+			ddl.pp.reassign_alleles(samples, combined_folder='tigger', save_plot=True, filename_prefix = args.file_prefix)
 			#remove if cleaning output - the important information is ported to sample folders already
 			if args.clean_output:
-				os.system('rm -r '+ind)
-	else:
-		#run on the whole thing at once
-		ddl.pp.reassign_alleles(samples, combined_folder='tigger', save_plot=True)
-		#remove if cleaning output - the important information is ported to sample folders already
-		if args.clean_output:
-			os.system('rm -r tigger')
+				os.system('rm -r tigger')
 	
-	#STEP FOUR - ddl.pp.assign_isotypes()
-	#also no tricks here
-	ddl.pp.assign_isotypes(samples, save_plot=True)
+		#STEP FOUR - ddl.pp.assign_isotypes()
+		#also no tricks here
+		ddl.pp.assign_isotypes(samples, save_plot=True, filename_prefix = args.file_prefix)
+	else:
+		#TODO: copy over the TR output file
 	
 	#at this stage it's safe to remove the per-sample dandelion/data/tmp folder if need be
 	if args.clean_output:
 		for sample in samples:
-			os.system('rm -r '+sample+'/dandelion/data/tmp')
+			os.system('rm -rf '+sample+'/dandelion/data/tmp')
 
 if __name__ == "__main__":
 	main()

--- a/docs/notebooks/singularity_preprocessing.ipynb
+++ b/docs/notebooks/singularity_preprocessing.ipynb
@@ -8,11 +8,11 @@
     "\n",
     "![dandelion_logo](img/dandelion_logo_illustration.png)\n",
     "\n",
-    "Arguably the greatest strength of the Dandelion package is a streamlined preprocessing setup making use of a variety of specialised single cell BCR algorithms:\n",
+    "Arguably the greatest strength of the Dandelion package is a streamlined preprocessing setup making use of a variety of specialised single cell VDJ algorithms:\n",
     "\n",
     "- V(D)J gene reannotation with [changeo's](https://changeo.readthedocs.io/en/stable/examples/10x.html) `AssignGenes.py` and `MakeDB.py`\n",
-    "- Reassigning heavy chain V gene alleles with [TIgGER](https://tigger.readthedocs.io/en/stable/)\n",
-    "- Reassigning constant region calls by blasting against a curated set of highly specific C gene sequences\n",
+    "- Reassigning heavy chain IG V gene alleles with [TIgGER](https://tigger.readthedocs.io/en/stable/)\n",
+    "- Reassigning IG constant region calls by blasting against a curated set of highly specific C gene sequences\n",
     "\n",
     "However, running this workflow requires a high number of dependencies and databases, which can be troublesome to set up. As such, we've put together a Singularity container that comes pre-configured with all of the required software and resources, allowing you to run the pre-processing pipeline with a single call and easy installation.\n",
     "\n",
@@ -30,11 +30,13 @@
     "\n",
     "You can then navigate to the directory holding all your sample folders and run Dandelion pre-processing like so:\n",
     "\n",
-    "    singularity run -B $PWD /path/to/sc-dandelion_latest.sif dandelion-preprocess\n",
+    "    singularity run -B $PWD /path/to/sc-dandelion_latest.sif dandelion-preprocess [optional arguments follow here]\n",
+    "\n",
+    "If you're running TR data rather than IG data, specify `--chain TR`. If you wish to process files that have a different prefix than `filtered`, e.g. `all_contig_annotations.csv` and `all_contig.fasta`, provide the desired file prefix with `--file_prefix`.\n",
     "\n",
     "## Optional arguments\n",
     "\n",
-    "By default, this workflow will analyse all provided samples jointly with TIgGER to maximise inference power, and in the event of multiple input folders will prepend the sample IDs to the cell barcodes to avoid erroneously merging barcodes overlapping between samples at this stage. TIgGER should be ran on a per-individual level. If running the workflow on multiple individuals' worth of data at once, or wanting to flag the cell barcodes in a non-default manner, information can be provided to the script in the form of a CSV file passed through the `--meta` argument:\n",
+    "By default, this workflow will analyse all provided IG samples jointly with TIgGER to maximise inference power, and in the event of multiple input folders will prepend the sample IDs to the cell barcodes to avoid erroneously merging barcodes overlapping between samples at this stage. TIgGER should be ran on a per-individual level. If running the workflow on multiple individuals' worth of data at once, or wanting to flag the cell barcodes in a non-default manner, information can be provided to the script in the form of a CSV file passed through the `--meta` argument:\n",
     "\n",
     "- The first row of the CSV needs to be a header identifying the information in the columns, and the first column needs to contain sample IDs.\n",
     "- Barcode flagging can be controlled by an optional `prefix`/`suffix` column. The pipeline will then add the specified prefixes/suffixes to the barcodes of the samples. This may be desirable, as corresponding gene expression samples are likely to have different IDs, and providing the matched ID will pre-format the BCR output to match the GEX nomenclature.\n",
@@ -58,13 +60,6 @@
     "\n",
     "If you're interested in more detail about the pre-processing this offers, or wish to use the workflow in a more advanced manner (e.g. by using your own databases), proceed to the pre-processing section of the tutorial."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -83,7 +78,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.8"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Added `--chain` and `--file_prefix` to container. Support logic for TCR analysis - avoid auto-adding samples as prefix in step one, `loci` argument in step two, skip step three and four. Added to documentation.

TODO: copy over the correct file after step two in TCR analysis, support file prefixes