### PR TITLE
Update find clones

### DIFF
--- a/dandelion/__init__.py
+++ b/dandelion/__init__.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 18:11:20
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2021-07-18 17:51:51
+# @Last Modified time: 2022-01-27 18:53:21
 
 from . import preprocessing as pp
 from . import utilities as utl
@@ -11,3 +11,5 @@ from . import plotting as pl
 from .utilities import read_pkl, read_h5, read_10x_airr, read_10x_vdj, from_scirpy, to_scirpy, Dandelion, update_metadata, concat, load_data
 from .logging import __version__, __author__, __email__, __classifiers__
 from . import logging
+
+read_h5ddl = read_h5

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2,7 +2,7 @@
 # @Author: Kelvin
 # @Date:   2021-02-11 12:22:40
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-01-27 19:50:06
+# @Last Modified time: 2022-01-27 21:27:31
 
 import os
 from collections import defaultdict
@@ -118,7 +118,7 @@ class Dandelion:
 
     def update_plus(
         self,
-        options: Literal[
+        option: Literal[
             'all', 'sequence', 'mutations', 'cdr3 lengths',
             'mutations and cdr3 lengths'] = 'mutations and cdr3 lengths'):
         """
@@ -127,7 +127,7 @@ class Dandelion:
         ----------
         self : Dandelion
             `Dandelion` object.
-        options : Literal
+        option : Literal
             One of 'all', 'sequence', 'mutations', 'cdr3 lengths',
             'mutations and cdr3 lengths'
         Returns
@@ -189,7 +189,7 @@ class Dandelion:
         vdjlengths = [x for x in vdjlengths if x in self.data]
         seqinfo = [x for x in seqinfo if x in self.data]
 
-        if options == 'all':
+        if option == 'all':
             if len(mutations) > 0:
                 update_metadata(self,
                                 retrieve=mutations,
@@ -205,12 +205,12 @@ class Dandelion:
                 update_metadata(self,
                                 retrieve=seqinfo,
                                 retrieve_mode='split and unique only')
-        if options == 'sequence':
+        if option == 'sequence':
             if len(seqinfo) > 0:
                 update_metadata(self,
                                 retrieve=seqinfo,
                                 retrieve_mode='split and unique only')
-        if options == 'mutations':
+        if option == 'mutations':
             if len(mutations) > 0:
                 update_metadata(self,
                                 retrieve=mutations,
@@ -218,12 +218,12 @@ class Dandelion:
                 update_metadata(self,
                                 retrieve=mutations,
                                 retrieve_mode='average')
-        if options == 'cdr3 lengths':
+        if option == 'cdr3 lengths':
             if len(vdjlengths) > 0:
                 update_metadata(self,
                                 retrieve=vdjlengths,
                                 retrieve_mode='split and average')
-        if options == 'mutations and cdr3 lengths':
+        if option == 'mutations and cdr3 lengths':
             if len(mutations) > 0:
                 update_metadata(self,
                                 retrieve=mutations,

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2,7 +2,7 @@
 # @Author: Kelvin
 # @Date:   2021-02-11 12:22:40
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-01-27 19:01:04
+# @Last Modified time: 2022-01-27 19:34:18
 
 import os
 from collections import defaultdict
@@ -115,6 +115,125 @@ class Dandelion:
         a deep copy of `Dandelion` class.
         """
         return copy.deepcopy(self)
+
+    def update_plus(
+        self,
+        options: Literal[
+            'all', 'sequence', 'mutations', 'cdr3 lengths',
+            'mutations and cdr3 lengths'] = 'mutations and cdr3 lengths'):
+        """
+        Retrieve additional data columns that are useful.
+        Parameters
+        ----------
+        self : Dandelion
+            `Dandelion` object.
+        options : Literal
+            One of 'all', 'sequence', 'mutations', 'cdr3 lengths',
+            'mutations and cdr3 lengths'
+        Returns
+        -------
+        Udpated metadata.
+        """
+        mutations_type = ['mu_count', 'mu_freq']
+        mutationsdef = [
+            'cdr_r', 'cdr_s', 'fwr_r', 'fwr_s', '1_r', '1_s', '2_r', '2_s',
+            '3_r', '3_s', '4_r', '4_s', '5_r', '5_s', '6_r', '6_s', '7_r',
+            '7_s', '8_r', '8_s', '9_r', '9_s', '10_r', '10_s', '11_r', '11_s',
+            '12_r', '12_s', '13_r', '13_s', '14_r', '14_s', '15_r', '15_s',
+            '16_r', '16_s', '17_r', '17_s', '18_r', '18_s', '19_r', '19_s',
+            '20_r', '20_s', '21_r', '21_s', '22_r', '22_s', '23_r', '23_s',
+            '24_r', '24_s', '25_r', '25_s', '26_r', '26_s', '27_r', '27_s',
+            '28_r', '28_s', '29_r', '29_s', '30_r', '30_s', '31_r', '31_s',
+            '32_r', '32_s', '33_r', '33_s', '34_r', '34_s', '35_r', '35_s',
+            '36_r', '36_s', '37_r', '37_s', '38_r', '38_s', '39_r', '39_s',
+            '40_r', '40_s', '41_r', '41_s', '42_r', '42_s', '43_r', '43_s',
+            '44_r', '44_s', '45_r', '45_s', '46_r', '46_s', '47_r', '47_s',
+            '48_r', '48_s', '49_r', '49_s', '50_r', '50_s', '51_r', '51_s',
+            '52_r', '52_s', '53_r', '53_s', '54_r', '54_s', '55_r', '55_s',
+            '56_r', '56_s', '57_r', '57_s', '58_r', '58_s', '59_r', '59_s',
+            '60_r', '60_s', '61_r', '61_s', '62_r', '62_s', '63_r', '63_s',
+            '64_r', '64_s', '65_r', '65_s', '66_r', '66_s', '67_r', '67_s',
+            '68_r', '68_s', '69_r', '69_s', '70_r', '70_s', '71_r', '71_s',
+            '72_r', '72_s', '73_r', '73_s', '74_r', '74_s', '75_r', '75_s',
+            '76_r', '76_s', '77_r', '77_s', '78_r', '78_s', '79_r', '79_s',
+            '80_r', '80_s', '81_r', '81_s', '82_r', '82_s', '83_r', '83_s',
+            '84_r', '84_s', '85_r', '85_s', '86_r', '86_s', '87_r', '87_s',
+            '88_r', '88_s', '89_r', '89_s', '90_r', '90_s', '91_r', '91_s',
+            '92_r', '92_s', '93_r', '93_s', '94_r', '94_s', '95_r', '95_s',
+            '96_r', '96_s', '97_r', '97_s', '98_r', '98_s', '99_r', '99_s',
+            '100_r', '100_s', '101_r', '101_s', '102_r', '102_s', '103_r',
+            '103_s', '104_r', '104_s', 'cdr1_r', 'cdr1_s', 'cdr2_r', 'cdr2_s',
+            'fwr1_r', 'fwr1_s', 'fwr2_r', 'fwr2_s', 'fwr3_r', 'fwr3_s', 'v_r',
+            'v_s'
+        ]
+        mutations = []
+        for m in mutations_type:
+            for d in mutationsdef:
+                mutations.append(m + '_' + d)
+        vdjlengths = [
+            'junction_length',
+            'junction_aa_length',
+            'np1_length',
+            'np2_length',
+        ]
+        seqinfo = [
+            'sequence', 'sequence_alignment', 'sequence_alignment_aa',
+            'junction', 'junction_aa', 'germline_alignment', 'fwr1', 'fwr1_aa',
+            'fwr2', 'fwr2_aa', 'fwr3', 'fwr3_aa', 'fwr4', 'fwr4_aa', 'cdr1',
+            'cdr1_aa', 'cdr2', 'cdr2_aa', 'cdr3', 'cdr3_aa',
+            'v_sequence_alignment_aa', 'd_sequence_alignment_aa',
+            'j_sequence_alignment_aa'
+        ]
+        mutations = [x for x in mutations if x in self.data]
+        vdjlenths = [x for x in vdjlenths if x in self.data]
+        seqinfo = [x for x in seqinfo if x in self.data]
+
+        if options == 'all':
+            if len(mutations) > 0:
+                update_metadata(self,
+                                retrieve=mutations,
+                                retrieve_mode='split and average')
+                update_metadata(self,
+                                retrieve=mutations,
+                                retrieve_mode='average')
+            if len(vdjlengths) > 0:
+                update_metadata(self,
+                                retrieve=vdjlengths,
+                                retrieve_mode='split and average')
+            if len(seqinfo) > 0:
+                update_metadata(self,
+                                retrieve=seqinfo,
+                                retrieve_mode='split and unique only')
+        if options == 'sequence':
+            if len(seqinfo) > 0:
+                update_metadata(self,
+                                retrieve=seqinfo,
+                                retrieve_mode='split and unique only')
+        if options == 'mutations':
+            if len(mutations) > 0:
+                update_metadata(self,
+                                retrieve=mutations,
+                                retrieve_mode='split and average')
+                update_metadata(self,
+                                retrieve=mutations,
+                                retrieve_mode='average')
+        if options == 'cdr3 lengths':
+            if len(vdjlengths) > 0:
+                update_metadata(self,
+                                retrieve=vdjlengths,
+                                retrieve_mode='split and average')
+        if options == 'mutations and cdr3 lengths':
+            if len(mutations) > 0:
+                update_metadata(self,
+                                retrieve=mutations,
+                                retrieve_mode='split and average')
+                update_metadata(self,
+                                retrieve=mutations,
+                                retrieve_mode='average')
+            if len(vdjlengths) > 0:
+                update_metadata(self,
+                                retrieve=vdjlengths,
+                                retrieve_mode='split and average')
 
     def update_germline(self,
                         corrected: Optional[Union[Dict, str]] = None,

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2,7 +2,7 @@
 # @Author: Kelvin
 # @Date:   2021-02-11 12:22:40
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-01-27 19:34:18
+# @Last Modified time: 2022-01-27 19:48:25
 
 import os
 from collections import defaultdict
@@ -185,7 +185,7 @@ class Dandelion:
             'j_sequence_alignment_aa'
         ]
         mutations = [x for x in mutations if x in self.data]
-        vdjlenths = [x for x in vdjlenths if x in self.data]
+        vdjlengths = [x for x in vdjlengths if x in self.data]
         seqinfo = [x for x in seqinfo if x in self.data]
 
         if options == 'all':

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2,7 +2,7 @@
 # @Author: Kelvin
 # @Date:   2021-02-11 12:22:40
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-01-27 18:30:42
+# @Last Modified time: 2022-01-27 19:01:04
 
 import os
 from collections import defaultdict
@@ -971,6 +971,8 @@ def update_metadata(self: Dandelion,
                 raise ValueError(
                     "Unable to initialize metadata due to missing keys. Please ensure either 'umi_count' or 'duplicate_count' is in the input data."
                 )
+    if 'cell_id' not in self.data:  # shortcut for bulk data to pretend every unique sequence is a cell?
+        self.data['cell_id'] = self.data['sequence_id']
 
     if not all([c in self.data for c in cols]):
         raise ValueError(

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2,7 +2,7 @@
 # @Author: Kelvin
 # @Date:   2021-02-11 12:22:40
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-01-27 19:48:25
+# @Last Modified time: 2022-01-27 19:50:06
 
 import os
 from collections import defaultdict
@@ -166,10 +166,11 @@ class Dandelion:
             'fwr1_r', 'fwr1_s', 'fwr2_r', 'fwr2_s', 'fwr3_r', 'fwr3_s', 'v_r',
             'v_s'
         ]
-        mutations = []
+        mutations = [] + mutations_type
         for m in mutations_type:
             for d in mutationsdef:
                 mutations.append(m + '_' + d)
+
         vdjlengths = [
             'junction_length',
             'junction_aa_length',

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2,7 +2,7 @@
 # @Author: Kelvin
 # @Date:   2021-02-11 12:22:40
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-01-14 17:00:29
+# @Last Modified time: 2022-01-27 18:30:42
 
 import os
 from collections import defaultdict
@@ -251,7 +251,8 @@ class Dandelion:
             writer.write(row)
 
     def write_h5(self,
-                 filename: str = 'dandelion_data.h5',
+                 filename: str = 'dandelion_data.h5ddl',
+                 keep_distance: bool = False,
                  complib: Literal['zlib', 'lzo', 'bzip2', 'blosc',
                                   'blosc:blosclz', 'blosc:lz4', 'blosc:lz4hc',
                                   'blosc:snappy', 'blosc:zlib',
@@ -348,17 +349,18 @@ class Dandelion:
         except:
             pass
 
-        try:
-            for d in self.distance:
-                # how to make this faster?
-                dat = pd.DataFrame(self.distance[d].toarray())
-                dat.to_hdf(filename,
-                           "distance/" + d,
-                           complib=comp,
-                           complevel=compression_level,
-                           **kwargs)
-        except:
-            pass
+        if keep_distance:
+            try:
+                for d in self.distance:
+                    # how to make this faster?
+                    dat = pd.DataFrame(self.distance[d].toarray())
+                    dat.to_hdf(filename,
+                               "distance/" + d,
+                               complib=comp,
+                               complevel=compression_level,
+                               **kwargs)
+            except:
+                pass
 
         with h5py.File(filename, "a") as hf:
             try:
@@ -385,6 +387,8 @@ class Dandelion:
             if self.threshold is not None:
                 tr = self.threshold
                 hf.create_dataset('threshold', data=tr)
+
+    write = write_h5ddl = write_h5  # shortcut
 
 
 class Query:

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -1,11 +1,41 @@
 #!/usr/bin/env python
 import dandelion as ddl
 import scanpy as sc
+import requests
+import os
+
+from fixtures import airr_reannotated
 
 
 def test_recipe():
-    adata = sc.datasets.pbmc3k()
+    try:
+        adata = sc.datasets.pbmc3k()
+    except:
+        fname = 'pbmc3k_filtered_gene_bc_matrices.tar.gz'
+        url = 'http://cf.10xgenomics.com/samples/cell-exp/1.1.0/pbmc3k/' + fname
+        r = requests.get(url, stream=True)
+        if r.status_code == 200:
+            with open('filtered_gene_bc_matrices.tar.gz', 'wb') as f:
+                f.write(r.raw.read())
+        os.system('tar -xzvf filtered_gene_bc_matrices.tar.gz')
+        adata = sc.read_10x_mtx('filtered_gene_bc_matrices/hg19')
     ddl.pp.external.recipe_scanpy_qc(adata)
     assert not adata.obs['filter_rna'].empty
     # ddl.pp.external.recipe_scanpy_qc(adata, mito_cutoff = None) # weird segmentation fault in the tests
     # assert not adata.obs['gmm_pct_count_clusters_keep'].empty
+
+
+def test_update_plus(airr_reannotated):
+    vdj = ddl.Dandelion(airr_reannotated)
+    vdj.update_plus()
+    assert 'mu_count' in vdj.metadata
+    vdj.update_plus(option = 'sequence')
+    assert 'sequence_VDJ' in vdj.metadata
+    vdj.update_plus(option = 'cdr3 lengths')
+    assert 'junction_aa_length_VDJ' in vdj.metadata
+    vdj = ddl.Dandelion(airr_reannotated)
+    vdj.update_plus(option = 'mutations')
+    assert 'mu_count' in vdj.metadata
+    vdj.update_plus(option = 'all')
+    assert 'sequence_VDJ' in vdj.metadata
+    vdj.update_plus(option = 'cdr3 lengths')

--- a/tests/test_tools_light.py
+++ b/tests/test_tools_light.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+import pandas as pd
+import dandelion as ddl
+
+from fixtures import (airr_reannotated, dummy_adata, create_testfolder)
+
+
+def test_setup(create_testfolder, airr_reannotated, dummy_adata):
+    vdj, adata = ddl.pp.filter_contigs(airr_reannotated, dummy_adata)
+    assert airr_reannotated.shape[0] == 9
+    assert vdj.data.shape[0] == 7
+    assert vdj.metadata.shape[0] == 4
+    assert adata.n_obs == 5
+    f = create_testfolder / "test.h5"
+    vdj.write_h5(f)
+    assert len(list(create_testfolder.iterdir())) == 1
+    vdj2 = ddl.read_h5(f)
+    assert vdj2.metadata is not None
+
+
+def test_find_clones(create_testfolder):
+    f = create_testfolder / "test.h5"
+    vdj = ddl.read_h5(f)
+    ddl.tl.find_clones(vdj, full_pairing_label=True)
+    assert not vdj.data.clone_id.empty
+    assert not vdj.metadata.clone_id.empty
+    assert len(set(x for x in vdj.metadata['clone_id'] if pd.notnull(x))) == 4
+    vdj.write_h5(f)


### PR DESCRIPTION
- Simpified the `find_clones` process to use a dictionary to pull down all possible groupings of contigs
- Added a feature called `update_plus` within the `Dandelion` class that will retrieve more standard columns that is often used.
- added alternative names for read/write_h5 (`read_h5ddl`, `write`, `write_h5ddl`)