### PR TITLE
fix bcr strict option

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
           - { python-version: 3.9, os: ubuntu-latest }
           - { python-version: 3.7, os: macos-latest }
           - { python-version: 3.8, os: macos-latest }
-          # - { python-version: 3.9, os: macos-latest } # segmentation fault =(
+          - { python-version: 3.9, os: macos-latest } # segmentation fault if multiprocessing?
     runs-on: ${{ matrix.config.os }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,8 @@ jobs:
           - { python-version: 3.9, os: ubuntu-latest }
           - { python-version: 3.7, os: macos-latest }
           - { python-version: 3.8, os: macos-latest }
-          - { python-version: 3.9, os: macos-latest } # segmentation fault if multiprocessing?
+          # - { python-version: 3.9, os: macos-latest } # segmentation fault due to missing py3.9 macOSX wheel https://github.com/rpy2/rpy2/issues/846
+          # disabled until it's fixed.
     runs-on: ${{ matrix.config.os }}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/bin/tigger-genotype.R
+++ b/bin/tigger-genotype.R
@@ -150,7 +150,7 @@ if (opt$VFIELD != v_call_genotyped) {
 }
 
 # Write genotyped data
-writeChangeoDb(db, file.path(opt$OUTDIR, paste0(opt$NAME, "_genotyped.",ext)))
+readr::write_tsv(db, file.path(opt$OUTDIR, paste0(opt$NAME, "_genotyped.",ext)), na = '')
 
 # Plot genotype
 plot_file <- file.path(opt$OUTDIR, paste0(opt$NAME, "_genotype.pdf"))

--- a/container/dandelion_preprocess.py
+++ b/container/dandelion_preprocess.py
@@ -65,11 +65,10 @@ def parse_args():
             'If passed, limits the contig space to ones that are set to ' +
             '"True" in the high_confidence column of the contig annotation.'))
     parser.add_argument(
-        '--reassign_dj',
-        action='store_true',
+        '--skip_reassign_dj',
+        action='store_false',
         help=(
-            'If passed, reassign d/j calls with blastn. ' +
-            'Only affects if loci is ig - will always reassign if loci is tr.'
+            'If passed, skips reassigning d/j calls with blastn when flavour=strict.'
         ))
     parser.add_argument(
         '--keep_trailing_hyphen_number',
@@ -103,8 +102,10 @@ def main():
     else:
         keep_trailing_hyphen_number_log = True
 
-    if args.chain == 'tr':
-        args.reassign_dj = True
+    if args.skip_reassign_dj:
+        skip_reassign_dj_log = False
+    else:
+        skip_reassign_dj_log = True
 
     logg.info(
         'command line parameters:\n',
@@ -119,7 +120,7 @@ def main():
          f'    --skip_format_header = {args.skip_format_header}\n'
          f'    --filter_to_high_confidence = {args.filter_to_high_confidence}\n'
          f'    --keep_trailing_hyphen_number = {keep_trailing_hyphen_number_log}\n'
-         f'    --reassign_dj = {args.reassign_dj}\n'
+         f'    --skip_reassign_dj = {skip_reassign_dj_log}\n'
          f'    --clean_output = {args.clean_output}\n'
          f'--------------------------------------------------------------\n'),
     )
@@ -195,20 +196,11 @@ def main():
 
     # STEP TWO - ddl.pp.reannotate_genes()
     # no tricks here
-    if args.chain == 'ig':
-        ddl.pp.reannotate_genes(samples,
-                                loci=args.chain,
-                                filename_prefix=filename_prefixes,
-                                flavour=args.flavour,
-                                reassign_dj=args.reassign_dj)
-    elif args.chain == 'tr':
-        ddl.pp.reannotate_genes(
-            samples,
-            loci=args.chain,
-            filename_prefix=filename_prefixes,
-            flavour=args.flavour,
-            reassign_dj=True,
-        )
+    ddl.pp.reannotate_genes(samples,
+                            loci=args.chain,
+                            filename_prefix=filename_prefixes,
+                            flavour=args.flavour,
+                            reassign_dj=args.skip_reassign_dj)
 
     # IG requires further preprocessing, TR is done now
     if args.chain == 'ig':

--- a/dandelion/preprocessing/_preprocessing.py
+++ b/dandelion/preprocessing/_preprocessing.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 17:56:02
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-11 22:35:39
+# @Last Modified time: 2022-03-12 11:24:29
 
 import os
 import pandas as pd
@@ -2149,8 +2149,9 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
                        region_definition: Optional[str] = None,
                        mutation_definition: Optional[str] = None,
                        frequency: bool = False,
-                       ncpu: int = 1,
-                       combine: bool = True) -> Union[pd.DataFrame, Dandelion]:
+                       combine: bool = True,
+                       **kwargs
+                       ) -> Union[pd.DataFrame, Dandelion]:
     """
     Run basic mutation load analysis.
 
@@ -2172,10 +2173,10 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
         passed to shazam's `observedMutations`. https://shazam.readthedocs.io/en/stable/topics/MUTATION_SCHEMES/
     frequency
         whether to return the results a frequency or counts. Default is True (frequency).
-     ncpu : int
-        number of cores to use. Default is 1.
     combine
         whether to return the results for replacement and silent mutations separately (False). Default is True (sum).
+    **kwargs
+        passed to shazam::observedMutations.
 
     Returns
     -------
@@ -2238,8 +2239,9 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
                                        regionDefinition=reg_d,
                                        mutationDefinition=mut_d,
                                        frequency=frequency,
-                                       nproc = ncpu,
-                                       combine=combine)
+                                       combine=combine,
+                                       **kwargs
+                                       )
         # pd_df = pandas2ri.rpy2py_dataframe(results)
         pd_df = results.copy()
     else:
@@ -2266,16 +2268,18 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
                                          regionDefinition=reg_d,
                                          mutationDefinition=mut_d,
                                          frequency=frequency,
-                                         nproc = ncpu,
-                                         combine=combine)
+                                         combine=combine,
+                                         **kwargs
+                                         )
         results_l = sh.observedMutations(dat_l_r,
                                          sequenceColumn=seq_,
                                          germlineColumn=germline_,
                                          regionDefinition=reg_d,
                                          mutationDefinition=mut_d,
                                          frequency=frequency,
-                                         nproc = ncpu,
-                                         combine=combine)
+                                         combine=combine,
+                                         **kwargs
+                                         )
         pd_df = pd.concat([results_h, results_l])
 
     pd_df.set_index('sequence_id', inplace=True, drop=False)

--- a/dandelion/preprocessing/_preprocessing.py
+++ b/dandelion/preprocessing/_preprocessing.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 17:56:02
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-11 21:27:48
+# @Last Modified time: 2022-03-11 21:32:14
 
 import os
 import pandas as pd
@@ -2195,10 +2195,9 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
     base = importr('base')
     if self.__class__ == Dandelion:
         dat = load_data(self.data)
-    elif self.__class__ == pd.DataFrame or os.path.isfile(self):
-        dat = load_data(self)
     else:
-        raise ValueError("{} object/file not found.".format(self))
+        dat = load_data(self)
+
     pandas2ri.activate()
     warnings.filterwarnings("ignore")
 

--- a/dandelion/preprocessing/_preprocessing.py
+++ b/dandelion/preprocessing/_preprocessing.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 17:56:02
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-10 17:46:36
+# @Last Modified time: 2022-03-10 19:54:04
 
 import os
 import pandas as pd
@@ -34,6 +34,7 @@ from Bio import Align
 from typing import Union, Sequence, Tuple, Optional
 from os import PathLike
 import anndata as ad
+import airr
 
 TRUES = ['T', 'True', 'true', 'TRUE', True]
 FALSES = ['F', 'False', 'false', 'FALSE', False]
@@ -4217,10 +4218,10 @@ def transfer_assignment(passfile: Union[PathLike, str],
                                                    '_germline_end_blastn']
                                     db_fail.at[i, call + '_source'] = 'blastn'
 
-                vend = db_faill['v_sequence_end']
-                dstart = db_faill['d_sequence_start']
-                dend = db_faill['d_sequence_end']
-                jstart = db_faill['j_sequence_start']
+                vend = db_fail['v_sequence_end']
+                dstart = db_fail['d_sequence_start']
+                dend = db_fail['d_sequence_end']
+                jstart = db_fail['j_sequence_start']
 
                 np1 = [
                     (v - d) - 1 if pd.notnull(v) and pd.notnull(d) else np.nan
@@ -4230,8 +4231,8 @@ def transfer_assignment(passfile: Union[PathLike, str],
                     (d - j) - 1 if pd.notnull(d) and pd.notnull(j) else np.nan
                     for d, j in zip(dend, jstart)
                 ]
-                db_faill['np1_length'] = np1
-                db_faill['np2_length'] = np2
+                db_fail['np1_length'] = np1
+                db_fail['np2_length'] = np2
 
             writer = airr.create_rearrangement(failfile,
                                                fields=db_fail.columns)

--- a/dandelion/preprocessing/_preprocessing.py
+++ b/dandelion/preprocessing/_preprocessing.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 17:56:02
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-11 19:12:29
+# @Last Modified time: 2022-03-11 21:27:48
 
 import os
 import pandas as pd
@@ -367,8 +367,6 @@ def assign_isotype(fasta: Union[str, PathLike],
                                                            float]] = (4, 4),
                    blastdb: Optional[str] = None,
                    allele: bool = False,
-                   parallel: bool = True,
-                   ncpu: Optional[int] = None,
                    filename_prefix: Optional[str] = None,
                    verbose: bool = False):
     """
@@ -408,11 +406,6 @@ def assign_isotype(fasta: Union[str, PathLike],
         path to blast database. Defaults to `$BLASTDB` environmental variable.
     allele : bool
         whether or not to return allele calls. Default is False.
-    parallel : bool
-        whether or not to use parallelization. Default is True.
-    ncpu : int
-        number of cores to use if parallel is True. Default is all
-        available minus 1.
     filename_prefix : str, Optional
         prefix of file name preceding '_contig'. None defaults to 'filtered'.
     verbose : bool
@@ -728,8 +721,6 @@ def assign_isotypes(fastas: Sequence,
                                                             float]] = (4, 4),
                     blastdb: Optional[str] = None,
                     allele: bool = False,
-                    parallel: bool = True,
-                    ncpu: Optional[int] = None,
                     filename_prefix: Optional[Union[Sequence, str]] = None,
                     verbose: bool = False):
     """
@@ -761,10 +752,6 @@ def assign_isotypes(fastas: Sequence,
         path to blast database. Defaults to `$BLASTDB` environmental variable.
     allele : bool
         whether or not to return allele calls. Default is False.
-    parallel : bool
-        whether or not to use parallelization. Default is True.
-    ncpu : int
-        number of cores to use if parallel is True. Default is all available - 1.
     filename_prefix : str, Optional
         list of prefixes of file names preceding '_contig'. None defaults to 'filtered'.
     verbose : bool
@@ -796,8 +783,6 @@ def assign_isotypes(fastas: Sequence,
                        figsize=figsize,
                        blastdb=blastdb,
                        allele=allele,
-                       parallel=parallel,
-                       ncpu=ncpu,
                        filename_prefix=filename_prefix[i],
                        verbose=verbose)
 
@@ -2164,6 +2149,7 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
                        region_definition: Optional[str] = None,
                        mutation_definition: Optional[str] = None,
                        frequency: bool = False,
+                       ncpu: int = 1,
                        combine: bool = True) -> Union[pd.DataFrame, Dandelion]:
     """
     Run basic mutation load analysis.
@@ -2186,6 +2172,8 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
         passed to shazam's `observedMutations`. https://shazam.readthedocs.io/en/stable/topics/MUTATION_SCHEMES/
     frequency
         whether to return the results a frequency or counts. Default is True (frequency).
+     ncpu : int
+        number of cores to use. Default is 1.
     combine
         whether to return the results for replacement and silent mutations separately (False). Default is True (sum).
 
@@ -2251,6 +2239,7 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
                                        regionDefinition=reg_d,
                                        mutationDefinition=mut_d,
                                        frequency=frequency,
+                                       nproc = ncpu,
                                        combine=combine)
         # pd_df = pandas2ri.rpy2py_dataframe(results)
         pd_df = results.copy()
@@ -2278,6 +2267,7 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
                                          regionDefinition=reg_d,
                                          mutationDefinition=mut_d,
                                          frequency=frequency,
+                                         nproc = ncpu,
                                          combine=combine)
         results_l = sh.observedMutations(dat_l_r,
                                          sequenceColumn=seq_,
@@ -2285,6 +2275,7 @@ def quantify_mutations(self: Union[Dandelion, str, PathLike],
                                          regionDefinition=reg_d,
                                          mutationDefinition=mut_d,
                                          frequency=frequency,
+                                         nproc = ncpu,
                                          combine=combine)
         pd_df = pd.concat([results_h, results_l])
 

--- a/dandelion/preprocessing/_preprocessing.py
+++ b/dandelion/preprocessing/_preprocessing.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 17:56:02
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-11 21:32:14
+# @Last Modified time: 2022-03-11 22:35:39
 
 import os
 import pandas as pd
@@ -705,7 +705,7 @@ def assign_isotype(fasta: Union[str, PathLike],
                 print(p)
     # move and rename
     move_to_tmp(fasta, filename_prefix)
-    # make_all(fasta, filename_prefix)
+    make_all(fasta, filename_prefix)
     rename_dandelion(fasta, filename_prefix)
 
 

--- a/dandelion/preprocessing/_preprocessing.py
+++ b/dandelion/preprocessing/_preprocessing.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 17:56:02
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-08 10:26:56
+# @Last Modified time: 2022-03-10 17:46:36
 
 import os
 import pandas as pd
@@ -3868,7 +3868,10 @@ def transfer_assignment(passfile: Union[PathLike, str],
         db_fail['locus'].fillna(value='', inplace=True)
         for i, r in db_fail.iterrows():
             if not present(r.locus):
-                calls = list(set([r.v_call[:3], r.d_call[:3], r.j_call[:3], r.c_call[:3]]))
+                calls = list(
+                    set([
+                        r.v_call[:3], r.d_call[:3], r.j_call[:3], r.c_call[:3]
+                    ]))
                 locus = ''.join([c for c in calls if present(c)])
                 if len(locus) == 3:
                     db_fail.at[i, 'locus'] = locus
@@ -3925,6 +3928,26 @@ def transfer_assignment(passfile: Union[PathLike, str],
                                                        '_call'] = db_pass.at[
                                                            i, call +
                                                            '_call_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_sequence_start'] = db_pass.at[
+                                                    i, call +
+                                                    '_sequence_start_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_sequence_end'] = db_pass.at[
+                                                    i, call +
+                                                    '_sequence_end_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_germline_start'] = db_pass.at[
+                                                    i, call +
+                                                    '_germline_start_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_germline_end'] = db_pass.at[
+                                                    i, call +
+                                                    '_germline_end_blastn']
                                             db_pass.at[i, call +
                                                        '_source'] = 'blastn'
                                     else:
@@ -3933,6 +3956,26 @@ def transfer_assignment(passfile: Union[PathLike, str],
                                                        '_call'] = db_pass.at[
                                                            i, call +
                                                            '_call_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_sequence_start'] = db_pass.at[
+                                                    i, call +
+                                                    '_sequence_start_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_sequence_end'] = db_pass.at[
+                                                    i, call +
+                                                    '_sequence_end_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_germline_start'] = db_pass.at[
+                                                    i, call +
+                                                    '_germline_start_blastn']
+                                            db_pass.at[
+                                                i, call +
+                                                '_germline_end'] = db_pass.at[
+                                                    i, call +
+                                                    '_germline_end_blastn']
                                             db_pass.at[i, call +
                                                        '_source'] = 'blastn'
                                 else:
@@ -3958,14 +4001,65 @@ def transfer_assignment(passfile: Union[PathLike, str],
                                 if eval1 > eval2:
                                     db_pass.at[i, call + '_call'] = db_pass.at[
                                         i, call + '_call_blastn']
+                                    db_pass.at[i, call +
+                                               '_sequence_start'] = db_pass.at[
+                                                   i, call +
+                                                   '_sequence_start_blastn']
+                                    db_pass.at[i, call +
+                                               '_sequence_end'] = db_pass.at[
+                                                   i, call +
+                                                   '_sequence_end_blastn']
+                                    db_pass.at[i, call +
+                                               '_germline_start'] = db_pass.at[
+                                                   i, call +
+                                                   '_germline_start_blastn']
+                                    db_pass.at[i, call +
+                                               '_germline_end'] = db_pass.at[
+                                                   i, call +
+                                                   '_germline_end_blastn']
                                     db_pass.at[i, call + '_source'] = 'blastn'
                             else:
                                 if present(eval2):
                                     db_pass.at[i, call + '_call'] = db_pass.at[
                                         i, call + '_call_blastn']
+                                    db_pass.at[i, call +
+                                               '_sequence_start'] = db_pass.at[
+                                                   i, call +
+                                                   '_sequence_start_blastn']
+                                    db_pass.at[i, call +
+                                               '_sequence_end'] = db_pass.at[
+                                                   i, call +
+                                                   '_sequence_end_blastn']
+                                    db_pass.at[i, call +
+                                               '_germline_start'] = db_pass.at[
+                                                   i, call +
+                                                   '_germline_start_blastn']
+                                    db_pass.at[i, call +
+                                               '_germline_end'] = db_pass.at[
+                                                   i, call +
+                                                   '_germline_end_blastn']
                                     db_pass.at[i, call + '_source'] = 'blastn'
 
-            db_pass.to_csv(passfile, sep='\t', index=False)
+                vend = db_pass['v_sequence_end']
+                dstart = db_pass['d_sequence_start']
+                dend = db_pass['d_sequence_end']
+                jstart = db_pass['j_sequence_start']
+
+                np1 = [
+                    (v - d) - 1 if pd.notnull(v) and pd.notnull(d) else np.nan
+                    for v, d in zip(vend, dstart)
+                ]
+                np2 = [
+                    (d - j) - 1 if pd.notnull(d) and pd.notnull(j) else np.nan
+                    for d, j in zip(dend, jstart)
+                ]
+                db_pass['np1_length'] = np1
+                db_pass['np2_length'] = np2
+
+            writer = airr.create_rearrangement(passfile,
+                                               fields=db_pass.columns)
+            for _, row in db_pass.iterrows():
+                writer.write(row)
 
         if db_fail is not None:
             db_fail_evalues = dict(db_fail[call + '_support'])
@@ -4011,6 +4105,26 @@ def transfer_assignment(passfile: Union[PathLike, str],
                                                        '_call'] = db_fail.at[
                                                            i, call +
                                                            '_call_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_sequence_start'] = db_fail.at[
+                                                    i, call +
+                                                    '_sequence_start_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_sequence_end'] = db_fail.at[
+                                                    i, call +
+                                                    '_sequence_end_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_germline_start'] = db_fail.at[
+                                                    i, call +
+                                                    '_germline_start_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_germline_end'] = db_fail.at[
+                                                    i, call +
+                                                    '_germline_end_blastn']
                                             db_fail.at[i, call +
                                                        '_source'] = 'blastn'
                                     else:
@@ -4019,6 +4133,26 @@ def transfer_assignment(passfile: Union[PathLike, str],
                                                        '_call'] = db_fail.at[
                                                            i, call +
                                                            '_call_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_sequence_start'] = db_fail.at[
+                                                    i, call +
+                                                    '_sequence_start_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_sequence_end'] = db_fail.at[
+                                                    i, call +
+                                                    '_sequence_end_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_germline_start'] = db_fail.at[
+                                                    i, call +
+                                                    '_germline_start_blastn']
+                                            db_fail.at[
+                                                i, call +
+                                                '_germline_end'] = db_fail.at[
+                                                    i, call +
+                                                    '_germline_end_blastn']
                                             db_fail.at[i, call +
                                                        '_source'] = 'blastn'
                                 else:
@@ -4044,11 +4178,62 @@ def transfer_assignment(passfile: Union[PathLike, str],
                                 if eval1 > eval2:
                                     db_fail.at[i, call + '_call'] = db_fail.at[
                                         i, call + '_call_blastn']
+                                    db_fail.at[i, call +
+                                               '_sequence_start'] = db_fail.at[
+                                                   i, call +
+                                                   '_sequence_start_blastn']
+                                    db_fail.at[i, call +
+                                               '_sequence_end'] = db_fail.at[
+                                                   i, call +
+                                                   '_sequence_end_blastn']
+                                    db_fail.at[i, call +
+                                               '_germline_start'] = db_fail.at[
+                                                   i, call +
+                                                   '_germline_start_blastn']
+                                    db_fail.at[i, call +
+                                               '_germline_end'] = db_fail.at[
+                                                   i, call +
+                                                   '_germline_end_blastn']
                                     db_fail.at[i, call + '_source'] = 'blastn'
                             else:
                                 if present(eval2):
                                     db_fail.at[i, call + '_call'] = db_fail.at[
                                         i, call + '_call_blastn']
+                                    db_fail.at[i, call +
+                                               '_sequence_start'] = db_fail.at[
+                                                   i, call +
+                                                   '_sequence_start_blastn']
+                                    db_fail.at[i, call +
+                                               '_sequence_end'] = db_fail.at[
+                                                   i, call +
+                                                   '_sequence_end_blastn']
+                                    db_fail.at[i, call +
+                                               '_germline_start'] = db_fail.at[
+                                                   i, call +
+                                                   '_germline_start_blastn']
+                                    db_fail.at[i, call +
+                                               '_germline_end'] = db_fail.at[
+                                                   i, call +
+                                                   '_germline_end_blastn']
                                     db_fail.at[i, call + '_source'] = 'blastn'
 
-            db_fail.to_csv(failfile, sep='\t', index=False)
+                vend = db_faill['v_sequence_end']
+                dstart = db_faill['d_sequence_start']
+                dend = db_faill['d_sequence_end']
+                jstart = db_faill['j_sequence_start']
+
+                np1 = [
+                    (v - d) - 1 if pd.notnull(v) and pd.notnull(d) else np.nan
+                    for v, d in zip(vend, dstart)
+                ]
+                np2 = [
+                    (d - j) - 1 if pd.notnull(d) and pd.notnull(j) else np.nan
+                    for d, j in zip(dend, jstart)
+                ]
+                db_faill['np1_length'] = np1
+                db_faill['np2_length'] = np2
+
+            writer = airr.create_rearrangement(failfile,
+                                               fields=db_fail.columns)
+            for _, row in db_fail.iterrows():
+                writer.write(row)

--- a/dandelion/tools/_tools.py
+++ b/dandelion/tools/_tools.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 # @Author: Kelvin
 # @Date:   2020-05-13 23:22:18
-# @Last Modified by:   kt16
-# @Last Modified time: 2022-03-11 17:42:10
+# @Last Modified by:   Kelvin
+# @Last Modified time: 2022-03-11 18:11:55
 
 import os
 import sys
@@ -832,7 +832,7 @@ def define_clones(self: Union[Dandelion, pd.DataFrame, str],
         outfile = "{}/{}_clone.tsv".format(outFolder, out_FilePrefix)
 
     write_airr(dat_h, h_file1)
-    write_airr(dat_l, l_file1)
+    write_airr(dat_l, l_file)
 
     if 'v_call_genotyped' in dat.columns:
         v_field = 'v_call_genotyped'

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2,7 +2,7 @@
 # @Author: Kelvin
 # @Date:   2021-02-11 12:22:40
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-07 09:42:40
+# @Last Modified time: 2022-03-11 17:44:21
 
 import os
 from collections import defaultdict
@@ -375,12 +375,8 @@ class Dandelion:
         **kwargs
             passed to `_pickle`.
         """
-        from airr import create_rearrangement
-        writer = create_rearrangement(filename,
-                                      fields=[x for x in self.data],
-                                      **kwargs)
-        for _, row in self.data.iterrows():
-            writer.write(row)
+        data = sanitize_data(self.data)
+        data.to_csv(filename, sep='\t', index=False, **kwargs)
 
     def write_h5(self,
                  filename: str = 'dandelion_data.h5ddl',

--- a/dandelion/utilities/_io.py
+++ b/dandelion/utilities/_io.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 14:01:32
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-11 20:33:38
+# @Last Modified time: 2022-03-11 22:19:55
 
 import os
 import json
@@ -778,7 +778,8 @@ def move_to_tmp(data: Sequence,
 
 
 def make_all(data: Sequence,
-             filename_prefix: Optional[Union[Sequence, str]] = None):
+             filename_prefix: Optional[Union[Sequence, str]] = None,
+             loci: Literal['ig', 'tr'] = 'tr'):
     if type(data) is not list:
         data = [data]
     if type(filename_prefix) is not list:
@@ -787,10 +788,17 @@ def make_all(data: Sequence,
         filename_prefix = [None for d in data]
 
     for i in range(0, len(data)):
-        filePath1 = check_filepath(data[i],
-                                   filename_prefix=filename_prefix[i],
-                                   endswith='_igblast_db-pass.tsv',
-                                   subdir='tmp')
+        if loci == 'tr':
+            filePath1 = check_filepath(data[i],
+                                       filename_prefix=filename_prefix[i],
+                                       endswith='_igblast_db-pass.tsv',
+                                       subdir='tmp')
+        else:
+            filePath1 = check_filepath(
+                data[i],
+                filename_prefix=filename_prefix[i],
+                endswith='_igblast_db-pass_genotyped.tsv',
+                subdir='tmp')
         filePath2 = check_filepath(data[i],
                                    filename_prefix=filename_prefix[i],
                                    endswith='_igblast_db-fail.tsv',
@@ -800,9 +808,25 @@ def make_all(data: Sequence,
             if filePath2 is not None:
                 df2 = pd.read_csv(filePath2, sep='\t')
                 df = df1.append(df2)
-                write_airr(df, filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv')
+                if loci == 'tr':
+                    write_airr(
+                        df,
+                        filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv')
+                else:
+                    write_airr(
+                        df,
+                        filePath1.rsplit('db-pass_genotyped.tsv')[0] +
+                        'db-all.tsv')
             else:
-                write_airr(df1, filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv')
+                if loci == 'tr':
+                    write_airr(
+                        df1,
+                        filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv')
+                else:
+                    write_airr(
+                        df1,
+                        filePath1.rsplit('db-pass_genotyped.tsv')[0] +
+                        'db-all.tsv')
 
 
 def rename_dandelion(data: Sequence,

--- a/dandelion/utilities/_io.py
+++ b/dandelion/utilities/_io.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 14:01:32
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-08 10:31:49
+# @Last Modified time: 2022-03-10 21:31:35
 
 import os
 import json
@@ -19,6 +19,7 @@ from ..utilities._core import *
 from os import PathLike
 from typing import Union, Sequence, Optional
 from collections import defaultdict, OrderedDict
+from airr import create_rearrangement, dump_rearrangement
 
 AIRR = [
     'cell_id',
@@ -748,7 +749,13 @@ def change_file_location(data: Sequence,
         ]
         for x in cols_to_merge:
             tmp[x] = pd.Series(airr_output[x])
-        tmp.to_csv(filePath, sep='\t', index=False)
+
+        # this part doesn't seem to want to work?
+        # writer = create_rearrangement(filePath, fields=tmp.columns)
+        # for _, row in tmp.iterrows():
+            # writer.write(row)
+        dump_rearrangement(tmp, filePath)
+
         cmd = ['rsync', '-azvh', filePath, filePath.rsplit('/', 2)[0]]
         run(cmd)
 
@@ -798,13 +805,17 @@ def make_all(data: Sequence,
             if filePath2 is not None:
                 df2 = pd.read_csv(filePath2, sep='\t')
                 df = df1.append(df2)
-                df.to_csv(filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv',
-                          sep='\t',
-                          index=False)
+                writer = create_rearrangement(
+                    filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv',
+                    fields=df.columns)
+                for _, row in df.iterrows():
+                    writer.write(row)
             else:
-                df1.to_csv(filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv',
-                           sep='\t',
-                           index=False)
+                writer = create_rearrangement(
+                    filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv',
+                    fields=df1.columns)
+                for _, row in df1.iterrows():
+                    writer.write(row)
 
 
 def rename_dandelion(data: Sequence,

--- a/dandelion/utilities/_io.py
+++ b/dandelion/utilities/_io.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 14:01:32
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-11 17:44:51
+# @Last Modified time: 2022-03-11 20:33:38
 
 import os
 import json
@@ -824,8 +824,3 @@ def rename_dandelion(data: Sequence,
             filePath.rsplit(endswith)[0] + '_dandelion.tsv'
         ]
         run(cmd)
-
-
-def write_airr(data, save):
-    data = sanitize_data(data)
-    data.to_csv(save, sep='\t', index=False)

--- a/dandelion/utilities/_io.py
+++ b/dandelion/utilities/_io.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 14:01:32
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-10 21:31:35
+# @Last Modified time: 2022-03-11 17:44:51
 
 import os
 import json
@@ -19,7 +19,6 @@ from ..utilities._core import *
 from os import PathLike
 from typing import Union, Sequence, Optional
 from collections import defaultdict, OrderedDict
-from airr import create_rearrangement, dump_rearrangement
 
 AIRR = [
     'cell_id',
@@ -750,11 +749,7 @@ def change_file_location(data: Sequence,
         for x in cols_to_merge:
             tmp[x] = pd.Series(airr_output[x])
 
-        # this part doesn't seem to want to work?
-        # writer = create_rearrangement(filePath, fields=tmp.columns)
-        # for _, row in tmp.iterrows():
-            # writer.write(row)
-        dump_rearrangement(tmp, filePath)
+        write_airr(tmp, filePath)
 
         cmd = ['rsync', '-azvh', filePath, filePath.rsplit('/', 2)[0]]
         run(cmd)
@@ -805,17 +800,9 @@ def make_all(data: Sequence,
             if filePath2 is not None:
                 df2 = pd.read_csv(filePath2, sep='\t')
                 df = df1.append(df2)
-                writer = create_rearrangement(
-                    filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv',
-                    fields=df.columns)
-                for _, row in df.iterrows():
-                    writer.write(row)
+                write_airr(df, filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv')
             else:
-                writer = create_rearrangement(
-                    filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv',
-                    fields=df1.columns)
-                for _, row in df1.iterrows():
-                    writer.write(row)
+                write_airr(df1, filePath1.rsplit('db-pass.tsv')[0] + 'db-all.tsv')
 
 
 def rename_dandelion(data: Sequence,
@@ -837,3 +824,8 @@ def rename_dandelion(data: Sequence,
             filePath.rsplit(endswith)[0] + '_dandelion.tsv'
         ]
         run(cmd)
+
+
+def write_airr(data, save):
+    data = sanitize_data(data)
+    data.to_csv(save, sep='\t', index=False)

--- a/dandelion/utilities/_utilities.py
+++ b/dandelion/utilities/_utilities.py
@@ -2,15 +2,17 @@
 # @Author: kt16
 # @Date:   2020-05-12 14:01:32
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-04 23:58:39
+# @Last Modified time: 2022-03-10 21:32:44
 
 import os
-from collections import defaultdict, Iterable
-from airr import RearrangementSchema
+import re
 import pandas as pd
 import numpy as np
+
+from collections import defaultdict, Iterable
+from airr import RearrangementSchema, create_rearrangement
 from subprocess import run
-import re
+
 from typing import Sequence, Tuple, Dict, Union, Optional
 try:
     from typing import Literal
@@ -521,4 +523,6 @@ def mask_dj(data, filename_prefix, d_evalue_threshold, j_evalue_threshold):
                 '' if s > j_evalue_threshold else c
                 for c, s in zip(dat['j_call'], dat['j_support_blastn'])
             ]
-            dat.to_csv(filePath, sep='\t', index=False)
+        writer = create_rearrangement(filePath, fields=dat.columns)
+        for _, row in dat.iterrows():
+            writer.write(row)

--- a/dandelion/utilities/_utilities.py
+++ b/dandelion/utilities/_utilities.py
@@ -2,7 +2,7 @@
 # @Author: kt16
 # @Date:   2020-05-12 14:01:32
 # @Last Modified by:   Kelvin
-# @Last Modified time: 2022-03-10 21:32:44
+# @Last Modified time: 2022-03-11 17:44:35
 
 import os
 import re
@@ -10,7 +10,7 @@ import pandas as pd
 import numpy as np
 
 from collections import defaultdict, Iterable
-from airr import RearrangementSchema, create_rearrangement
+from airr import RearrangementSchema
 from subprocess import run
 
 from typing import Sequence, Tuple, Dict, Union, Optional
@@ -329,22 +329,27 @@ def sanitize_data(data, ignore='clone_id'):
             if RearrangementSchema.properties[d]['type'] in [
                     'string', 'boolean', 'integer'
             ]:
-                data[d].replace([None, np.nan, pd.NA, ''], '', inplace=True)
+                data[d].replace([None, np.nan, pd.NA, 'nan', ''],
+                                '',
+                                inplace=True)
                 if RearrangementSchema.properties[d]['type'] == 'integer':
                     data[d] = [
                         int(x) if present(x) else ''
                         for x in pd.to_numeric(data[d])
                     ]
             else:
-                data[d].replace([None, pd.NA, ''], np.nan, inplace=True)
+                data[d].replace([None, pd.NA, np.nan, 'nan', ''],
+                                np.nan,
+                                inplace=True)
         else:
             if d != ignore:
                 try:
                     data[d] = pd.to_numeric(data[d])
                 except:
-                    data[d].replace(to_replace=[None, np.nan, pd.NA],
-                                    value='',
-                                    inplace=True)
+                    data[d].replace(
+                        to_replace=[None, np.nan, pd.NA, 'nan', ''],
+                        value='',
+                        inplace=True)
         if re.search('mu_freq', d):
             data[d] = [
                 float(x) if present(x) else np.nan
@@ -369,16 +374,22 @@ def sanitize_data_for_saving(data):
             if RearrangementSchema.properties[d]['type'] in [
                     'string', 'boolean'
             ]:
-                tmp[d].replace([None, np.nan, pd.NA, ''], '', inplace=True)
+                tmp[d].replace([None, np.nan, pd.NA, 'nan', ''],
+                               '',
+                               inplace=True)
             if RearrangementSchema.properties[d]['type'] in [
                     'integer', 'number'
             ]:
-                tmp[d].replace([None, np.nan, pd.NA, ''], np.nan, inplace=True)
+                tmp[d].replace([None, np.nan, pd.NA, 'nan', ''],
+                               np.nan,
+                               inplace=True)
         else:
             try:
                 tmp[d] = pd.to_numeric(tmp[d])
             except:
-                tmp[d].replace([None, pd.NA, np.nan], '', inplace=True)
+                tmp[d].replace([None, pd.NA, np.nan, 'nan', ''],
+                               '',
+                               inplace=True)
     return (tmp)
 
 
@@ -523,6 +534,5 @@ def mask_dj(data, filename_prefix, d_evalue_threshold, j_evalue_threshold):
                 '' if s > j_evalue_threshold else c
                 for c, s in zip(dat['j_call'], dat['j_support_blastn'])
             ]
-        writer = create_rearrangement(filePath, fields=dat.columns)
-        for _, row in dat.iterrows():
-            writer.write(row)
+
+        write_airr(dat, filePath)

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - python>=3.7,<=3.8
 - pandoc
 - pyyaml
+- ipython_genutils
 - adjustText
 - statsmodels
 - pytables

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - nbsphinx
   - sphinx-autodoc-typehints
   - annoy==1.16.3
-  - rpy2==3.4.2
+  - rpy2>=3.4.0
   - pytest-cov
   - -r requirements.txt
   - git+https://www.github.com/zktuong/nxviz.git

--- a/environment.yml
+++ b/environment.yml
@@ -21,7 +21,7 @@ dependencies:
   - nbsphinx
   - sphinx-autodoc-typehints
   - annoy==1.16.3
-  - rpy2>=3.4.0
+  - rpy2==3.4.2
   - pytest-cov
   - -r requirements.txt
   - git+https://www.github.com/zktuong/nxviz.git

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -16,7 +16,6 @@ def database_paths():
     """Database paths for tests."""
     db = {
         'igblast_db': "container/database/igblast/",
-        'igblast_db': "container/database/igblast/",
         'germline': "container/database/germlines/imgt/human/vdj/",
         'blastdb': "container/database/blast/human/",
         'blastdb_fasta': "container/database/blast/human/human_BCR_C.fasta",

--- a/tests/test_mouse.py
+++ b/tests/test_mouse.py
@@ -35,7 +35,9 @@ def test_reannotategenes(create_testfolder, database_paths_mouse):
     ddl.pp.reannotate_genes(str(create_testfolder),
                             igblast_db=database_paths_mouse['igblast_db'],
                             germline=database_paths_mouse['germline'],
-                            org='mouse')
+                            org='mouse',
+                            reassign_dj = False,
+                            )
     assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 4
 
 

--- a/tests/test_mouse2.py
+++ b/tests/test_mouse2.py
@@ -31,16 +31,6 @@ def test_formatfasta(create_testfolder):
     assert len(list((create_testfolder / 'dandelion').iterdir())) == 2
 
 
-def test_reannotategenes_other(create_testfolder, database_paths_mouse):
-    ddl.pp.format_fastas(str(create_testfolder))
-    ddl.pp.reannotate_genes(str(create_testfolder),
-                            igblast_db=database_paths_mouse['igblast_db'],
-                            germline=database_paths_mouse['germline'],
-                            extended = False,
-                            org='mouse')
-    assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 4
-
-
 def test_reannotategenes_original(create_testfolder, database_paths_mouse):
     ddl.pp.format_fastas(str(create_testfolder))
     ddl.pp.reannotate_genes(str(create_testfolder),
@@ -49,3 +39,13 @@ def test_reannotategenes_original(create_testfolder, database_paths_mouse):
                             flavour = 'original',
                             org='mouse')
     assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 4
+
+
+def test_reannotategenes_other(create_testfolder, database_paths_mouse):
+    ddl.pp.format_fastas(str(create_testfolder))
+    ddl.pp.reannotate_genes(str(create_testfolder),
+                            igblast_db=database_paths_mouse['igblast_db'],
+                            germline=database_paths_mouse['germline'],
+                            extended = False,
+                            org='mouse')
+    assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 6

--- a/tests/test_mouse3.py
+++ b/tests/test_mouse3.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+import pandas as pd
+import dandelion as ddl
+from pathlib import Path
+
+from fixtures_mouse import (fasta_10x_mouse, annotation_10x_mouse,
+                            database_paths_mouse, dummy_adata_mouse,
+                            balbc_ighg_primers)
+from fixtures import (processed_files, create_testfolder)
+
+
+def test_write_fasta(create_testfolder, fasta_10x_mouse):
+    out_fasta = str(create_testfolder) + "/filtered_contig.fasta"
+    fh = open(out_fasta, "w")
+    fh.close()
+    out = ''
+    for l in fasta_10x_mouse:
+        out = '>' + l + '\n' + fasta_10x_mouse[l] + '\n'
+        ddl.utl.Write_output(out, out_fasta)
+    assert len(list(create_testfolder.iterdir())) == 1
+
+
+def test_write_annotation(create_testfolder, annotation_10x_mouse):
+    out_file = str(create_testfolder) + "/filtered_contig_annotations.csv"
+    annotation_10x_mouse.to_csv(out_file, index=False)
+    assert len(list(create_testfolder.iterdir())) == 2
+
+
+def test_formatfasta(create_testfolder):
+    ddl.pp.format_fastas(str(create_testfolder))
+    assert len(list((create_testfolder / 'dandelion').iterdir())) == 2
+
+
+def test_reannotategenes_strict(create_testfolder, database_paths_mouse):
+    ddl.pp.format_fastas(str(create_testfolder))
+    ddl.pp.reannotate_genes(str(create_testfolder),
+                            igblast_db=database_paths_mouse['igblast_db'],
+                            germline=database_paths_mouse['germline'],
+                            flavour = 'strict',
+                            reassign_dj = True,
+                            org='mouse')
+    assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 6
+
+
+def test_reassignalleles(create_testfolder, database_paths_mouse):
+    ddl.pp.reassign_alleles(str(create_testfolder),
+                            combined_folder='test_mouse',
+                            germline=database_paths_mouse['germline'],
+                            org='mouse',
+                            novel=True,
+                            plot=False)
+    assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 9
+
+
+def test_updateblastdb(database_paths_mouse):
+    ddl.utl.makeblastdb(database_paths_mouse['blastdb_fasta'])
+    assert len(list(Path(database_paths_mouse['blastdb']).iterdir())) == 10
+
+
+def test_assignsisotypes(create_testfolder, database_paths_mouse,
+                         balbc_ighg_primers):
+    ddl.pp.assign_isotypes(str(create_testfolder),
+                           blastdb=database_paths_mouse['blastdb_fasta'],
+                           correction_dict=balbc_ighg_primers,
+                           plot=False)
+    assert len(list((create_testfolder / 'dandelion').iterdir())) == 2
+
+
+def test_filtercontigs(create_testfolder, processed_files, dummy_adata_mouse):
+    f = create_testfolder / str('dandelion/' + processed_files['filtered'])
+    dat = pd.read_csv(f, sep='\t')
+    vdj, adata = ddl.pp.filter_contigs(dat, dummy_adata_mouse)
+    f1 = create_testfolder / "test.h5"
+    f2 = create_testfolder / "test.h5ad"
+    vdj.write_h5(f1)
+    adata.write_h5ad(f2)
+    assert dat.shape[0] == 1285
+    assert vdj.data.shape[0] == 782
+    assert vdj.metadata.shape[0] == 392
+    assert adata.n_obs == 547

--- a/tests/test_mouse3.py
+++ b/tests/test_mouse3.py
@@ -74,7 +74,7 @@ def test_filtercontigs(create_testfolder, processed_files, dummy_adata_mouse):
     f2 = create_testfolder / "test.h5ad"
     vdj.write_h5(f1)
     adata.write_h5ad(f2)
-    assert dat.shape[0] == 1285
-    assert vdj.data.shape[0] == 782
-    assert vdj.metadata.shape[0] == 392
+    assert dat.shape[0] == 1278
+    assert vdj.data.shape[0] == 776
+    assert vdj.metadata.shape[0] == 389
     assert adata.n_obs == 547

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -66,8 +66,8 @@ def test_reannotate_fails(create_testfolder, database_paths):
 
 
 @pytest.mark.parametrize("filename,expected",
-                         [pytest.param('filtered', 3),
-                          pytest.param('all', 6)])
+                         [pytest.param('filtered', 5),
+                          pytest.param('all', 10)])
 def test_reannotategenes(create_testfolder, database_paths, filename,
                          expected):
     ddl.pp.reannotate_genes(str(create_testfolder),
@@ -89,8 +89,8 @@ def test_reassign_alleles_fails(create_testfolder, database_paths):
 
 
 @pytest.mark.parametrize("filename,combine,expected", [
-    pytest.param('filtered', 'reassigned_filtered', 9),
-    pytest.param('all', 'reassigned_all', 12)
+    pytest.param('filtered', 'reassigned_filtered', 13),
+    pytest.param('all', 'reassigned_all', 16)
 ])
 def test_reassignalleles(create_testfolder, database_paths, filename, combine,
                          expected):
@@ -160,15 +160,15 @@ def test_update_germlines(create_testfolder, processed_files, database_paths):
 
 
 @pytest.mark.parametrize(
-    "freq,colname",
-    [pytest.param(True, 'mu_freq'),
-     pytest.param(False, 'mu_count')])
-def test_quantify_mut(create_testfolder, processed_files, freq, colname):
+    "freq,colname,dtype",
+    [pytest.param(True, 'mu_freq', float),
+     pytest.param(False, 'mu_count', int)])
+def test_quantify_mut(create_testfolder, processed_files, freq, colname, dtype):
     f = create_testfolder / str('dandelion/' + processed_files['filtered'])
     ddl.pp.quantify_mutations(f, frequency=freq)
     dat = pd.read_csv(f, sep='\t')
     assert not dat[colname].empty
-    assert dat[colname].dtype == float
+    assert dat[colname].dtype == dtype
 
 
 @pytest.mark.parametrize(

--- a/tests/test_travdv.py
+++ b/tests/test_travdv.py
@@ -47,7 +47,7 @@ def test_reannotategenes(create_testfolder, database_paths):
                             igblast_db=database_paths['igblast_db'],
                             germline=database_paths['germline'],
                             loci='tr')
-    assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 7
+    assert len(list((create_testfolder / 'dandelion/tmp').iterdir())) == 9
     assert len(list((create_testfolder / 'dandelion').iterdir())) == 2
 
 


### PR DESCRIPTION
Turns out the issue was with the dtypes being casted wrongly and the airr readers were failing specifically before and after running tigger. 

Forcing a sanitisation step each time airr format is to be written to ensure that integers were not mixing with float seemed to be the key - the mix dtype prevented columns like np1 from being read it properly for CreateGermlines.py.