### PR TITLE
remove deprecated function from docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -100,7 +100,6 @@ Dandelion
    :toctree: modules
 
    copy
-   update_germline
    store_germline_reference
    update_metadata
    write


### PR DESCRIPTION
remove `update_germline`