### PR TITLE
fix entry of anndata with NaN 'sequence_id' values

### DIFF
--- a/.github/workflows/tests_weekly.yml
+++ b/.github/workflows/tests_weekly.yml
@@ -139,7 +139,7 @@ jobs:
       - name: Install Dandelion
         run: |
           python -m pip install git+https://github.com/emdann/milopy.git
-          python -m pip install palantir==1.0.1
+          python -m pip install palantir
           python -m pip install ".[scirpy]"
 
       - name: Install ubuntu R dependencies

--- a/dandelion/utilities/_io.py
+++ b/dandelion/utilities/_io.py
@@ -1002,8 +1002,6 @@ def from_ak(airr: "Array") -> pd.DataFrame:
 
     if "sequence_id" in df.columns:
         df.set_index("sequence_id", drop=False, inplace=True)
-    if "cell_id" not in df.columns:
-        df["cell_id"] = [c.split("_contig")[0] for c in df["sequence_id"]]
 
     return df
 

--- a/dandelion/utilities/_io.py
+++ b/dandelion/utilities/_io.py
@@ -1002,6 +1002,8 @@ def from_ak(airr: "Array") -> pd.DataFrame:
 
     if "sequence_id" in df.columns:
         df.set_index("sequence_id", drop=False, inplace=True)
+    if "cell_id" not in df.columns:
+        df["cell_id"] = [c.split("_contig")[0] for c in df["sequence_id"]]
 
     return df
 


### PR DESCRIPTION
In `from_ak` function previously, it does not account for empty (NaN) `sequence_id` values and the values of `cell_id` column were populated wrt values of `sequence_id` which would cause an error if the values of `sequence_id` were NaN.

This change includes using `adata.obs,index` values as `cell_id` which would then avoid this circular dependency when filling up `sequence_id` values in `from_ak` function