### PR TITLE
disregard non productive contigs when reporting chain/locus status

### DIFF
--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -806,8 +806,8 @@ class Dandelion:
         ] = "split and merge",
         collapse_alleles: bool = True,
         reinitialize: bool = True,
-        verbose: bool = False,
         by_celltype: bool = False,
+        report_status_productive: bool = True,
     ):
         """
         A `Dandelion` initialisation function to update and populate the `.metadata` slot.
@@ -847,10 +847,10 @@ class Dandelion:
         reinitialize : bool, optional
             whether or not to reinitialize the current metadata.
             useful when updating older versions of `dandelion` to newer version.
-        verbose : bool, optional
-            whether to print progress.
         by_celltype : bool, optional
             whether to return the query/update by celltype.
+        report_status_productive : bool, optional
+            whether to report the locus and chain status for only productive contigs.
 
         Raises
         ------
@@ -910,7 +910,9 @@ class Dandelion:
 
         metadata_status = self.metadata
         if (metadata_status is None) or reinitialize:
-            initialize_metadata(self, cols, clonekey, collapse_alleles)
+            initialize_metadata(
+                self, cols, clonekey, collapse_alleles, report_status_productive
+            )
 
         tmp_metadata = self.metadata.copy()
 
@@ -1776,7 +1778,11 @@ class Query:
 
 
 def initialize_metadata(
-    vdj_data, cols: List[str], clonekey: str, collapse_alleles: bool
+    vdj_data,
+    cols: List[str],
+    clonekey: str,
+    collapse_alleles: bool,
+    report_productive_only: bool,
 ):
     """Initialize Dandelion metadata."""
     init_dict = {}
@@ -2104,7 +2110,9 @@ def initialize_metadata(
                             for t in tmp_metadata[c]
                         ]
 
-    tmp_metadata["locus_status"] = format_locus(tmp_metadata)
+    tmp_metadata["locus_status"] = format_locus(
+        tmp_metadata, productive_only=report_productive_only
+    )
     tmp_metadata["chain_status"] = format_chain_status(
         tmp_metadata["locus_status"]
     )
@@ -2185,6 +2193,7 @@ def update_metadata(
     collapse_alleles: bool = True,
     reinitialize: bool = True,
     by_celltype: bool = False,
+    report_status_productive: bool = True,
 ):
     """
     A `Dandelion` initialisation function to update and populate the `.metadata` slot.
@@ -2228,6 +2237,8 @@ def update_metadata(
         useful when updating older versions of `dandelion` to newer version.
     by_celltype : bool, optional
         whether to return the query/update by celltype.
+    report_status_productive : bool, optional
+        whether to report the locus and chain status for only productive contigs.
 
     Raises
     ------
@@ -2287,7 +2298,9 @@ def update_metadata(
 
     metadata_status = vdj_data.metadata
     if (metadata_status is None) or reinitialize:
-        initialize_metadata(vdj_data, cols, clonekey, collapse_alleles)
+        initialize_metadata(
+            vdj_data, cols, clonekey, collapse_alleles, report_status_productive
+        )
 
     tmp_metadata = vdj_data.metadata.copy()
 

--- a/dandelion/utilities/_core.py
+++ b/dandelion/utilities/_core.py
@@ -2062,21 +2062,45 @@ def initialize_metadata(
     multi, multic = {}, {}
 
     if "c_call" + suffix_vdj in tmp_metadata:
-        for k in tmp_metadata["c_call" + suffix_vdj]:
+        for k, p in zip(
+            tmp_metadata["c_call" + suffix_vdj],
+            tmp_metadata["productive" + suffix_vdj],
+        ):
             if isinstance(k, str):
-                isotype.append(
-                    "|".join(
-                        [
-                            str(z)
-                            for z in [
-                                conversion_dict[y.split(",")[0].lower()]
-                                for y in [
-                                    re.sub("[0-9]", "", x) for x in k.split("|")
+                if report_productive_only:
+                    isotype.append(
+                        "|".join(
+                            [
+                                str(z)
+                                for z, pp in zip(
+                                    [
+                                        conversion_dict[y.split(",")[0].lower()]
+                                        for y in [
+                                            re.sub("[0-9]", "", x)
+                                            for x in k.split("|")
+                                        ]
+                                    ],
+                                    p.split("|"),
+                                )
+                                if pp in TRUES
+                            ]
+                        )
+                    )
+                else:
+                    isotype.append(
+                        "|".join(
+                            [
+                                str(z)
+                                for z in [
+                                    conversion_dict[y.split(",")[0].lower()]
+                                    for y in [
+                                        re.sub("[0-9]", "", x)
+                                        for x in k.split("|")
+                                    ]
                                 ]
                             ]
-                        ]
+                        )
                     )
-                )
             else:
                 isotype.append("None")
         tmp_metadata["isotype"] = isotype

--- a/dandelion/utilities/_utilities.py
+++ b/dandelion/utilities/_utilities.py
@@ -797,21 +797,51 @@ def format_call(
 
 
 def format_locus(
-    metadata: pd.DataFrame, suffix_vdj: str = "_VDJ", suffix_vj: str = "_VJ"
+    metadata: pd.DataFrame,
+    suffix_vdj: str = "_VDJ",
+    suffix_vj: str = "_VJ",
+    productive_only: bool = True,
 ) -> pd.Series:
     """Extract locus call value from data."""
     locus_1 = dict(metadata["locus" + suffix_vdj])
     locus_2 = dict(metadata["locus" + suffix_vj])
     constant_1 = dict(metadata["isotype_status"])
-
+    prod_1 = dict(metadata["productive" + suffix_vdj])
+    prod_2 = dict(metadata["productive" + suffix_vj])
     locus_dict = {}
     for i in metadata.index:
-        loc1 = {
-            e: l for e, l in enumerate([ll for ll in locus_1[i].split("|")])
-        }
-        loc2 = {
-            e: l for e, l in enumerate([ll for ll in locus_2[i].split("|")])
-        }
+        if productive_only:
+            loc1 = {
+                e: l
+                for e, l in enumerate(
+                    [
+                        ll
+                        for ll, p in zip(
+                            locus_1[i].split("|"), prod_1[i].split("|")
+                        )
+                        if p in TRUES
+                    ]
+                )
+            }
+            loc2 = {
+                e: l
+                for e, l in enumerate(
+                    [
+                        ll
+                        for ll, p in zip(
+                            locus_2[i].split("|"), prod_2[i].split("|")
+                        )
+                        if p in TRUES
+                    ]
+                )
+            }
+        else:
+            loc1 = {
+                e: l for e, l in enumerate([ll for ll in locus_1[i].split("|")])
+            }
+            loc2 = {
+                e: l for e, l in enumerate([ll for ll in locus_2[i].split("|")])
+            }
         loc1x, loc2x = [], []
         if not all([px == "None" for px in loc1.values()]):
             loc1xx = list(loc1.values())

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -341,3 +341,9 @@ def test_to_scirpy_v2(create_testfolder, annotation_10x, fasta_10x):
     assert vdjx.data.shape[0] == 35
     vdjx = ddl.from_scirpy(mdata)
     assert vdjx.data.shape[0] == 35
+
+
+def test_locus_productive(airr_generic):
+    """Just test if this works. don't care about the output."""
+    tmp = ddl.Dandelion(airr_generic, report_status_productive=True)
+    tmp = ddl.Dandelion(airr_generic, report_status_productive=False)


### PR DESCRIPTION
@suochenqu requested to change the locus/chain status to mainly reflect only productive contigs.

This is now the default behaviour, but can be toggled with `report_status_productive=True` or `report_status_productive=False` with `ddl.Dandelion`.


for some context:
![image](https://github.com/zktuong/dandelion/assets/26215587/3f335115-9c5f-433a-9523-cca84375d7e9)
there are extra contigs in the J only TRA and TRB
there's no term at the moment for describing this combination other that extra pair and it's not technically a single pair either
it's orphan VDJ if we consider only productive contigs.

chain_status depends on locus_status -> which currently says Extra VDJ + TRA -> this only checks at the locus column for how many TRB and TRA contigs there are. if chain_status detects the word Extra (and in this case there are 2 TRB VDJ contigs, hence extra VDJ), it will then just simply flag this as an Extra pair