### PR TITLE
Clean up warnings

### DIFF
--- a/container/environment.yml
+++ b/container/environment.yml
@@ -17,12 +17,18 @@ dependencies:
   - pip
   - pytest
   - tbb
-  - r-base>=4.4.0
+  - rpy2
+  - r-base
+  - r-essentials
+  - r-optparse
+  - r-tigger
+  - r-shazam
+  - r-airr
+  - r-alakazam
   - igblast
   - blast
   - pip:
       - scanpy>=1.7.0
       - git+https://www.github.com/zktuong/dandelion.git
-      - rpy2
       - biopython
       - receptor-utils

--- a/container/environment.yml
+++ b/container/environment.yml
@@ -17,14 +17,12 @@ dependencies:
   - pip
   - pytest
   - tbb
-  - rpy2
-  - r-optparse
-  - r-alakazam
-  - r-tigger
-  - r-airr
-  - r-shazam
+  - r-base>=4.4.0
   - igblast
   - blast
   - pip:
       - scanpy>=1.7.0
       - git+https://www.github.com/zktuong/dandelion.git
+      - rpy2
+      - biopython
+      - receptor-utils

--- a/container/environment_test.yml
+++ b/container/environment_test.yml
@@ -17,11 +17,17 @@ dependencies:
   - pip
   - pytest
   - tbb
-  - r-base>=4.4.0
+  - rpy2
+  - r-base
+  - r-essentials
+  - r-optparse
+  - r-tigger
+  - r-shazam
+  - r-airr
+  - r-alakazam
   - igblast
   - blast
   - pip:
       - scanpy>=1.7.0
-      - rpy2
       - biopython
       - receptor-utils

--- a/container/environment_test.yml
+++ b/container/environment_test.yml
@@ -17,13 +17,11 @@ dependencies:
   - pip
   - pytest
   - tbb
-  - rpy2
-  - r-optparse
-  - r-alakazam
-  - r-tigger
-  - r-airr
-  - r-shazam
+  - r-base>=4.4.0
   - igblast
   - blast
   - pip:
       - scanpy>=1.7.0
+      - rpy2
+      - biopython
+      - receptor-utils

--- a/container/sc-dandelion.def
+++ b/container/sc-dandelion.def
@@ -15,7 +15,6 @@ From: ubuntu:latest
     scripts/prepare_imgt_database.py /share/prepare_imgt_database.py
     scripts/prepare_ogrdb_database.py /share/prepare_ogrdb_database.py
     scripts/utils.py /share/utils.py
-    optional_file /share/optional_file
     tests /tests
 
 %post

--- a/container/sc-dandelion_remote.def
+++ b/container/sc-dandelion_remote.def
@@ -15,7 +15,6 @@ From: ubuntu:latest
     dandelion/container/scripts/prepare_imgt_database.py /share/prepare_imgt_database.py
     dandelion/container/scripts/prepare_ogrdb_database.py /share/prepare_ogrdb_database.py
     dandelion/container/scripts/utils.py /share/utils.py
-    dandelion/container/optional_file /share/optional_file
     dandelion/container/tests /tests
 
 %post

--- a/container/sc-dandelion_test.def
+++ b/container/sc-dandelion_test.def
@@ -15,7 +15,6 @@ From: ubuntu:latest
     scripts/prepare_imgt_database.py /share/prepare_imgt_database.py
     scripts/prepare_ogrdb_database.py /share/prepare_ogrdb_database.py
     scripts/utils.py /share/utils.py
-    optional_file /share/optional_file
     tests /tests
 
 %post

--- a/container/scripts/prepare_imgt_database.py
+++ b/container/scripts/prepare_imgt_database.py
@@ -98,9 +98,9 @@ def download_germline_and_process(
     imgt_out_dict = {
         "human": ["Homo sapiens", "Homo_sapiens"],
         "mouse": ["Mus musculus", "Mus_musculus"],
-        "rat": ["Rattus norvegicus", "Rattus_norvegicus"],
+        # "rat": ["Rattus norvegicus", "Rattus_norvegicus"], # seems like there's an issue retrieving this from IMGT/GENE-DB 18/07/2024
         "rabbit": ["Oryctolagus cuniculus", "Oryctolagus_cuniculus"],
-        "rhesus_monkey": ["Macaca mulatta", "Macaca_mulatta"],
+        # "rhesus_monkey": ["Macaca mulatta", "Macaca_mulatta"], # seems like there's an issue retrieving this from IMGT/GENE-DB 18/07/2024
     }
     url = f"{source}/GENElect?query={query_type}+{chain}&species={query}{url_suffix}"
     file_name = (
@@ -224,7 +224,7 @@ def main():
         "mouse": "Mus",
         # "rat": "Rattus+norvegicus", # seems like there's an issue retrieving this from IMGT/GENE-DB 18/07/2024
         "rabbit": "Oryctolagus+cuniculus",
-        "rhesus_monkey": "Macaca+mulatta",
+        # "rhesus_monkey": "Macaca+mulatta", # seems like there's an issue retrieving this from IMGT/GENE-DB 18/07/2024
     }
     igblast_out_dict = {
         "vdj": "",

--- a/container/scripts/prepare_imgt_database.py
+++ b/container/scripts/prepare_imgt_database.py
@@ -222,7 +222,7 @@ def main():
     species_dict = {
         "human": "Homo+sapiens",
         "mouse": "Mus",
-        "rat": "Rattus+norvegicus",
+        # "rat": "Rattus+norvegicus", # seems like there's an issue retrieving this from IMGT/GENE-DB 18/07/2024
         "rabbit": "Oryctolagus+cuniculus",
         "rhesus_monkey": "Macaca+mulatta",
     }

--- a/container/scripts/prepare_ogrdb_database.py
+++ b/container/scripts/prepare_ogrdb_database.py
@@ -135,9 +135,8 @@ def copy_ogrdb_aux_to_igblast(
     out_dir : str | Path
         Location of new database folder.
     """
-    OUT_DIR = (Path(out_dir) / "optional_file").mkdir(
-        parents=True, exist_ok=True
-    )
+    OUT_DIR = Path(out_dir) / "optional_file"
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
     for org in ["human", "mouse"]:
         cmd = [
             "annotate_j",

--- a/container/scripts/prepare_ogrdb_database.py
+++ b/container/scripts/prepare_ogrdb_database.py
@@ -122,6 +122,7 @@ def return_ogrdb_info(species: str) -> tuple[list[str], dict[str, str]]:
 
 
 def copy_ogrdb_aux_to_igblast(
+    igblast_out: str | Path,
     out_dir: str | Path,
 ):
     """
@@ -129,15 +130,22 @@ def copy_ogrdb_aux_to_igblast(
 
     Parameters
     ----------
+    igblast_out : str | Path
+        Location of downloaded fasta files for igblast.
     out_dir : str | Path
         Location of new database folder.
     """
-    Path(out_dir).mkdir(parents=True, exist_ok=True)
-    shutil.copytree(
-        Path(__file__).parent / "optional_file",
-        Path(out_dir),
-        dirs_exist_ok=True,
+    OUT_DIR = (Path(out_dir) / "optional_file").mkdir(
+        parents=True, exist_ok=True
     )
+    for org in ["human", "mouse"]:
+        cmd = [
+            "annotate_j",
+            str(Path(igblast_out) / f"ogrdb_{org}_ig_j.fasta"),
+            str(OUT_DIR / f"{org}_gl_ogrdb.aux"),
+        ]
+        res = subprocess.run(cmd, stdout=subprocess.PIPE)
+        logging.info(res.stdout.decode("utf-8"))
 
 
 def download_germline_and_process(
@@ -433,6 +441,7 @@ def main():
             write_fasta(seqs, out_file)
     logging.info("Preparing auxiliary files for igblast")
     copy_ogrdb_aux_to_igblast(
+        igblast_out,
         out_dir / "igblast" / "optional_file",
     )
     # convert to igblast database

--- a/container/scripts/prepare_ogrdb_database.py
+++ b/container/scripts/prepare_ogrdb_database.py
@@ -136,7 +136,7 @@ def copy_ogrdb_aux_to_igblast(
     out_dir : str | Path
         Location of new database folder.
     """
-    OUT_DIR = Path(out_dir) / "optional_file"
+    OUT_DIR = Path(out_dir)
     OUT_DIR.mkdir(parents=True, exist_ok=True)
     for org in ["human", "mouse"]:
         cmd = [

--- a/container/scripts/prepare_ogrdb_database.py
+++ b/container/scripts/prepare_ogrdb_database.py
@@ -55,7 +55,8 @@ def query_ogrdb_set_info(species: str):
         Name of species.
 
     """
-    url = f"https://ogrdb.airr-community.org/api/germline/sets/{species.capitalize()}"
+    species_dict = {"human": "homo%20sapiens", "mouse": "mus%20musculus"}
+    url = f"https://ogrdb.airr-community.org/api/germline/sets/{species_dict[species]}"
     headers = {"accept": "application/json"}
     # Create a request object with the URL and headers
     request = Request(url, headers=headers)

--- a/container/scripts/setup_mamba.sh
+++ b/container/scripts/setup_mamba.sh
@@ -1,5 +1,5 @@
 # set up miniforge
-apt-get --allow-releaseinfo-change update && apt-get install -y curl git gcc
+apt-get --allow-releaseinfo-change update && apt-get install -y curl git gcc language-pack-en
 curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 bash Miniforge3-$(uname)-$(uname -m).sh -b -p "/opt/conda"
 rm Miniforge3-$(uname)-$(uname -m).sh
@@ -12,11 +12,9 @@ echo "conda activate sc-dandelion-container" | tee -a $SINGULARITY_ENVIRONMENT
 echo "export GERMLINE=/share/database/germlines/" | tee -a $SINGULARITY_ENVIRONMENT
 echo "export IGDATA=/share/database/igblast/" | tee -a $SINGULARITY_ENVIRONMENT
 echo "export BLASTDB=/share/database/blast/" | tee -a $SINGULARITY_ENVIRONMENT
+echo "LANG=en_US.UTF-8" | tee -a $SINGULARITY_ENVIRONMENT
 chmod +x /share/dandelion_preprocess.py
 chmod +x /share/changeo_clonotypes.py
 # install dependencies
 mamba env update --name sc-dandelion-container -f environment.yml
 mamba activate sc-dandelion-container
-Rscript -e 'install.packages(c("optparse", "airr", "BiocManager"), repos = "http://cran.us.r-project.org")'
-Rscript -e 'BiocManager::install(c("Biostrings", "GenomicAlignments", "IRanges"))'
-Rscript -e 'install.packages(c("shazam", "alakazam", "tigger"), repos = "http://cran.us.r-project.org")'

--- a/container/scripts/setup_mamba.sh
+++ b/container/scripts/setup_mamba.sh
@@ -1,5 +1,5 @@
 # set up miniforge
-apt-get --allow-releaseinfo-change update && apt-get install -y curl git
+apt-get --allow-releaseinfo-change update && apt-get install -y curl git gcc
 curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
 bash Miniforge3-$(uname)-$(uname -m).sh -b -p "/opt/conda"
 rm Miniforge3-$(uname)-$(uname -m).sh
@@ -17,3 +17,6 @@ chmod +x /share/changeo_clonotypes.py
 # install dependencies
 mamba env update --name sc-dandelion-container -f environment.yml
 mamba activate sc-dandelion-container
+Rscript -e 'install.packages(c("optparse", "airr", "BiocManager"), repos = "http://cran.us.r-project.org")'
+Rscript -e 'BiocManager::install(c("Biostrings", "GenomicAlignments", "IRanges"))'
+Rscript -e 'install.packages(c("shazam", "alakazam", "tigger"), repos = "http://cran.us.r-project.org")'

--- a/dandelion/preprocessing/_preprocessing.py
+++ b/dandelion/preprocessing/_preprocessing.py
@@ -2143,7 +2143,9 @@ def filter_contigs(
         for b in barcode:
             bc_.update({b: "True"})
         contig_check["has_contig"] = pd.Series(bc_)
-        contig_check.replace(np.nan, "No_contig", inplace=True)
+        contig_check["has_contig"] = contig_check["has_contig"].replace(
+            np.nan, "No_contig"
+        )
         adata_.obs["has_contig"] = pd.Series(contig_check["has_contig"])
     else:
         adata_provided = False
@@ -2270,7 +2272,9 @@ def filter_contigs(
             failed2 = {b: "False" for b in failed}
             bc_2.update(failed2)
         contig_check["contig_QC_pass"] = pd.Series(bc_2)
-        contig_check.replace(np.nan, "No_contig", inplace=True)
+        contig_check["contig_QC_pass"] = contig_check["contig_QC_pass"].replace(
+            np.nan, "No_contig"
+        )
         adata_.obs["contig_QC_pass"] = pd.Series(contig_check["contig_QC_pass"])
         adata_.obs["filter_contig"] = adata_.obs_names.isin(filter_ids)
         if filter_rna:
@@ -4568,13 +4572,13 @@ def transfer_assignment(
     if os.path.isfile(failfile):
         db_fail = load_data(failfile)
         # should be pretty safe to fill this in
-        db_fail["vj_in_frame"].fillna(value="F", inplace=True)
-        db_fail["productive"].fillna(value="F", inplace=True)
-        db_fail["c_call"].fillna(value="", inplace=True)
-        db_fail["v_call"].fillna(value="", inplace=True)
-        db_fail["d_call"].fillna(value="", inplace=True)
-        db_fail["j_call"].fillna(value="", inplace=True)
-        db_fail["locus"].fillna(value="", inplace=True)
+        db_fail["vj_in_frame"] = db_fail["vj_in_frame"].fillna(value="F")
+        db_fail["productive"] = db_fail["productive"].fillna(value="F")
+        db_fail["c_call"] = db_fail["c_call"].fillna(value="")
+        db_fail["v_call"] = db_fail["v_call"].fillna(value="")
+        db_fail["d_call"] = db_fail["d_call"].fillna(value="")
+        db_fail["j_call"] = db_fail["j_call"].fillna(value="")
+        db_fail["locus"] = db_fail["locus"].fillna(value="")
         for i, r in db_fail.iterrows():
             if not present(r.locus):
                 calls = list(
@@ -4596,14 +4600,16 @@ def transfer_assignment(
                 db_pass_evalues = dict(db_pass[call + "_support"])
             if call + "_score" in db_pass:
                 db_pass_scores = dict(db_pass[call + "_score"])
-            db_pass[call + "_call"].fillna(value="", inplace=True)
+            db_pass[call + "_call"] = db_pass[call + "_call"].fillna(value="")
             db_pass_call = dict(db_pass[call + "_call"])
             if call + "_support" in db_pass:
                 db_pass[call + "_support_igblastn"] = pd.Series(db_pass_evalues)
             if call + "_score" in db_pass:
                 db_pass[call + "_score_igblastn"] = pd.Series(db_pass_scores)
             db_pass[call + "_call_igblastn"] = pd.Series(db_pass_call)
-            db_pass[call + "_call_igblastn"].fillna(value="", inplace=True)
+            db_pass[call + "_call_igblastn"] = db_pass[
+                call + "_call_igblastn"
+            ].fillna(value="")
             for col in blast_result:
                 if col not in ["sequence_id", "cell_id"]:
                     db_pass[col + "_blastn"] = pd.Series(blast_result[col])
@@ -4612,7 +4618,9 @@ def transfer_assignment(
                         call + "_sequence_alignment",
                         call + "_germline_alignment",
                     ]:
-                        db_pass[col + "_blastn"].fillna(value="", inplace=True)
+                        db_pass[col + "_blastn"] = db_pass[
+                            col + "_blastn"
+                        ].fillna(value="")
             db_pass[call + "_source"] = ""
             if overwrite:
                 for i in db_pass["sequence_id"]:
@@ -4837,14 +4845,16 @@ def transfer_assignment(
                 db_fail_evalues = dict(db_fail[call + "_support"])
             if call + "_score" in db_fail:
                 db_fail_scores = dict(db_fail[call + "_score"])
-            db_fail[call + "_call"].fillna(value="", inplace=True)
+            db_fail[call + "_call"] = db_fail[call + "_call"].fillna(value="")
             db_fail_call = dict(db_fail[call + "_call"])
             if call + "_support" in db_fail:
                 db_fail[call + "_support_igblastn"] = pd.Series(db_fail_evalues)
             if call + "_score" in db_fail:
                 db_fail[call + "_score_igblastn"] = pd.Series(db_fail_scores)
             db_fail[call + "_call_igblastn"] = pd.Series(db_fail_call)
-            db_fail[call + "_call_igblastn"].fillna(value="", inplace=True)
+            db_fail[call + "_call_igblastn"] = db_fail[
+                call + "_call_igblastn"
+            ].fillna(value="")
             for col in blast_result:
                 if col not in ["sequence_id", "cell_id"]:
                     db_fail[col + "_blastn"] = pd.Series(blast_result[col])
@@ -4853,7 +4863,9 @@ def transfer_assignment(
                         call + "_sequence_alignment",
                         call + "_germline_alignment",
                     ]:
-                        db_fail[col + "_blastn"].fillna(value="", inplace=True)
+                        db_fail[col + "_blastn"] = db_fail[
+                            col + "_blastn"
+                        ].fillna(value="")
             db_fail[call + "_source"] = ""
             if overwrite:
                 for i in db_fail["sequence_id"]:
@@ -5191,7 +5203,9 @@ def check_contigs(
         for b in barcode:
             bc_.update({b: "True"})
         contig_check["has_contig"] = pd.Series(bc_)
-        contig_check.replace(np.nan, "No_contig", inplace=True)
+        contig_check["has_contig"] = contig_check["has_contig"].replace(
+            np.nan, "No_contig"
+        )
         adata_.obs["has_contig"] = pd.Series(contig_check["has_contig"])
     else:
         adata_provided = False
@@ -5243,7 +5257,7 @@ def check_contigs(
         dat_["umi_count"].update(dat["umi_count"])
         for column in ["ambiguous", "extra"]:
             dat_[column] = dat[column]
-            dat_[column].fillna("T", inplace=True)
+            dat_[column] = dat_[column].fillna("T")
         dat = dat_.copy()
 
     if filter_extra:

--- a/dandelion/utilities/_utilities.py
+++ b/dandelion/utilities/_utilities.py
@@ -401,8 +401,9 @@ def sanitize_data(data, ignore="clone_id"):
                 "boolean",
                 "integer",
             ]:
-                data[d].replace(
-                    [None, np.nan, pd.NA, "nan", ""], "", inplace=True
+                data[d] = data[d].replace(
+                    [None, np.nan, pd.NA, "nan", ""],
+                    "",
                 )
                 if RearrangementSchema.properties[d]["type"] == "integer":
                     data[d] = [
@@ -410,18 +411,18 @@ def sanitize_data(data, ignore="clone_id"):
                         for x in pd.to_numeric(data[d])
                     ]
             else:
-                data[d].replace(
-                    [None, pd.NA, np.nan, "nan", ""], np.nan, inplace=True
+                data[d] = data[d].replace(
+                    [None, pd.NA, np.nan, "nan", ""],
+                    np.nan,
                 )
         else:
             if d != ignore:
                 try:
                     data[d] = pd.to_numeric(data[d])
                 except:
-                    data[d].replace(
+                    data[d] = data[d].replace(
                         to_replace=[None, np.nan, pd.NA, "nan", ""],
                         value="",
-                        inplace=True,
                     )
         if re.search("mu_freq", d):
             data[d] = [
@@ -464,8 +465,9 @@ def sanitize_blastn(data):
                 "boolean",
                 "integer",
             ]:
-                data[d].replace(
-                    [None, np.nan, pd.NA, "nan", ""], "", inplace=True
+                data[d] = data[d].replace(
+                    [None, np.nan, pd.NA, "nan", ""],
+                    "",
                 )
                 if RearrangementSchema.properties[d]["type"] == "integer":
                     data[d] = [
@@ -473,17 +475,17 @@ def sanitize_blastn(data):
                         for x in pd.to_numeric(data[d])
                     ]
             else:
-                data[d].replace(
-                    [None, pd.NA, np.nan, "nan", ""], np.nan, inplace=True
+                data[d] = data[d].replace(
+                    [None, pd.NA, np.nan, "nan", ""],
+                    np.nan,
                 )
         else:
             try:
                 data[d] = pd.to_numeric(data[d])
             except:
-                data[d].replace(
+                data[d] = data[d].replace(
                     to_replace=[None, np.nan, pd.NA, "nan", ""],
                     value="",
-                    inplace=True,
                 )
     return data
 
@@ -497,22 +499,25 @@ def sanitize_data_for_saving(data):
                 "string",
                 "boolean",
             ]:
-                tmp[d].replace(
-                    [None, np.nan, pd.NA, "nan", ""], "", inplace=True
+                tmp[d] = tmp[d].replace(
+                    [None, np.nan, pd.NA, "nan", ""],
+                    "",
                 )
             if RearrangementSchema.properties[d]["type"] in [
                 "integer",
                 "number",
             ]:
-                tmp[d].replace(
-                    [None, np.nan, pd.NA, "nan", ""], np.nan, inplace=True
+                tmp[d] = tmp[d].replace(
+                    [None, np.nan, pd.NA, "nan", ""],
+                    np.nan,
                 )
         else:
             try:
                 tmp[d] = pd.to_numeric(tmp[d])
             except:
-                tmp[d].replace(
-                    [None, pd.NA, np.nan, "nan", ""], "", inplace=True
+                tmp[d] = tmp[d].replace(
+                    [None, pd.NA, np.nan, "nan", ""],
+                    "",
                 )
     return tmp
 
@@ -527,22 +532,6 @@ def validate_airr(data):
             int_columns.append(d)
         except:
             pass
-    bool_columns = [
-        "rev_comp",
-        "productive",
-        "vj_in_frame",
-        "stop_codon",
-        "complete_vdj",
-    ]
-    str_columns = list(tmp.dtypes[tmp.dtypes == "object"].index)
-    columns = [
-        c
-        for c in list(set(int_columns + str_columns + bool_columns))
-        if c in tmp
-    ]
-    # if len(columns) > 0:
-    # for c in columns:
-    # tmp[c].fillna("", inplace=True)
     for _, row in tmp.iterrows():
         contig = Contig(row).contig
         for required in [


### PR DESCRIPTION
Clean up the vomit of `FutureWarnings` around the use of `inplace=True` where relevant. 

Fixed the R warnings that was coming up due to weird locale settings, which also causes R to crash with a segmentation fault.

Removed the building of databases for `rat` and `monkey` since there seems to be some trouble retrieving them from `IMGT/GENE-DB`.

Fixed the url paths for OGRDB from `HUMAN` and `MOUSE` to `homo%20sapiens` and `mus%20musculus`.

Changed how `.aux` files for `OGRDB` are created - now `annotate_j` from `receptor-utils` is used `https://williamdlees.github.io/receptor_utils/_build/html/annotate_j.html` instead of having to manually check it all the time!

