### PR TITLE
create proper link to the vdj data

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dandelion_manuscript"]
+	path = dandelion_manuscript
+	url = https://github.com/zktuong/dandelion-demo-files.git

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Suo, C., Polanski, K., Dann, E. et al. ***Dandelion uses the single-cell adaptiv
 
 The data used in the Nature Biotechnology paper is available at a separate [repository](https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript).
 
-This repository also includes a Git submodule for the dandelion_manuscript folder, which is stored in the dandelion-demo-files repository (click link above that says `dandelion_manuscript`)
+This repository also includes a Git submodule for the dandelion_manuscript folder, which is stored in the dandelion-demo-files repository (click link above that says [dandelion_manuscript @ d922602](https://github.com/zktuong/dandelion-demo-files/tree/d92260217e4653577881482812ee336838a5f673))
 
 
 `dandelion` was originally published at [***Nature Medicine***](https://www.nature.com/articles/s41591-021-01329-2):

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Suo, C., Polanski, K., Dann, E. et al. ***Dandelion uses the single-cell adaptiv
 
 The data used in the Nature Biotechnology paper is available at a separate [repository](https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript).
 
-This repository also includes a Git submodule for the dandelion_manuscript folder, which is stored in the dandelion-demo-files repository (click link above that says [dandelion_manuscript @ d922602](https://github.com/zktuong/dandelion-demo-files/tree/d92260217e4653577881482812ee336838a5f673))
+This repository also includes a Git submodule for the dandelion_manuscript folder, which is stored in the dandelion-demo-files repository (click link above that says `dandelion_manuscript`)
 
 
 `dandelion` was originally published at [***Nature Medicine***](https://www.nature.com/articles/s41591-021-01329-2):

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Please cite the following if you use version 0.3.0 onwards:
 
 Suo, C., Polanski, K., Dann, E. et al. ***Dandelion uses the single-cell adaptive immune receptor repertoire to explore lymphocyte developmental origins***. Nat Biotechnol (2023). https://doi.org/10.1038/s41587-023-01734-7
 
+The data used in the Nature Biotechnology paper is available at a separate [repository](https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript).
+
 
 `dandelion` was originally published at [***Nature Medicine***](https://www.nature.com/articles/s41591-021-01329-2):
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Suo, C., Polanski, K., Dann, E. et al. ***Dandelion uses the single-cell adaptiv
 
 The data used in the Nature Biotechnology paper is available at a separate [repository](https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript).
 
+This repository also includes a Git submodule for the dandelion_manuscript folder, which is stored in the dandelion-demo-files repository (click link above that says `dandelion_manuscript`)
+
 
 `dandelion` was originally published at [***Nature Medicine***](https://www.nature.com/articles/s41591-021-01329-2):
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -158,7 +158,7 @@ lymphocyte developmental origins**. Nature Biotechnology 2023.04.13; doi:
 https://doi.org/10.1038/s41587-023-01734-7*
 
 The data used in the Nature Biotechnology papers can be found at
-`a separate repository <https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript>`__.
+`a separate repository <https://github.com/zktuong/dandelion-demo-files>`__.
 
 ``dandelion`` was originally published in:
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -157,6 +157,9 @@ Zewen Kelvin Tuong, Menna R Clatworthy, Sarah A Teichmann.*
 lymphocyte developmental origins**. Nature Biotechnology 2023.04.13; doi:
 https://doi.org/10.1038/s41587-023-01734-7*
 
+The data used in the Nature Biotechnology papers can be found at
+`a separate repository <https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript>`__.
+
 ``dandelion`` was originally published in:
 
 .. [Stephenson2021] Stephenson *et al.* (2021),

--- a/docs/notebooks/8-pseudobulk-trajectory.ipynb
+++ b/docs/notebooks/8-pseudobulk-trajectory.ipynb
@@ -83,6 +83,14 @@
   },
   {
    "cell_type": "markdown",
+   "id": "70e10873",
+   "metadata": {},
+   "source": [
+    "The full data used in the Nature Biotechnology paper is available at a separate [repository](https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "caroline-output",
    "metadata": {},
    "source": [

--- a/docs/notebooks/Q5-pseudobulk.ipynb
+++ b/docs/notebooks/Q5-pseudobulk.ipynb
@@ -70,13 +70,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "competent-china",
    "metadata": {},
    "outputs": [],
    "source": [
     "if not os.path.exists(\"demo-pseudobulk.h5ad\"):\n",
-    "    os.system(\"wget ftp://ftp.sanger.ac.uk/pub/users/kp9/demo-pseudobulk.h5ad\")\n"
+    "    os.system(\"wget ftp://ftp.sanger.ac.uk/pub/users/kp9/demo-pseudobulk.h5ad\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3dd4c76",
+   "metadata": {},
+   "source": [
+    "The full data used in the Nature Biotechnology paper is available at a separate [repository](https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript)."
    ]
   },
   {
@@ -89,13 +97,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "emotional-february",
    "metadata": {},
    "outputs": [],
    "source": [
     "adata = sc.read(\"demo-pseudobulk.h5ad\")\n",
-    "adata = ddl.tl.setup_vdj_pseudobulk(adata)\n"
+    "adata = ddl.tl.setup_vdj_pseudobulk(adata)"
    ]
   },
   {
@@ -150,7 +158,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "committed-bread",
    "metadata": {},
    "outputs": [
@@ -168,7 +176,7 @@
     }
    ],
    "source": [
-    "pb_adata\n"
+    "pb_adata"
    ]
   },
   {
@@ -181,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "casual-forum",
    "metadata": {},
    "outputs": [
@@ -211,7 +219,7 @@
    ],
    "source": [
     "sc.tl.pca(pb_adata)\n",
-    "sc.pl.pca(pb_adata, color=\"anno_lvl_2_final_clean\")\n"
+    "sc.pl.pca(pb_adata, color=\"anno_lvl_2_final_clean\")"
    ]
   },
   {
@@ -545,7 +553,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "id": "excessive-album",
    "metadata": {},
    "outputs": [
@@ -569,7 +577,7 @@
     "sc.tl.pca(pb_adata)\n",
     "sc.pp.neighbors(pb_adata)\n",
     "sc.tl.umap(pb_adata)\n",
-    "sc.pl.umap(pb_adata, color=\"annot_high\")\n"
+    "sc.pl.umap(pb_adata, color=\"annot_high\")"
    ]
   }
  ],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,6 +112,7 @@ docs = [
   "presto>=0.5.0,<0.7.3",
   "pyyaml",
   "yamlordereddictloader",
+  "sphinx<8.2",
   "nbsphinx<=0.9.2",
   "sphinx-autodoc-typehints<=3.0.1",
   "sphinx_rtd_theme<=3.0.2",


### PR DESCRIPTION
The full data used in the Nature Biotechnology paper is available at a separate [repository](https://github.com/zktuong/dandelion-demo-files/tree/master/dandelion_manuscript).