### PR TITLE
change the default for update plus

### DIFF
--- a/src/dandelion/utilities/_core.py
+++ b/src/dandelion/utilities/_core.py
@@ -1310,7 +1310,7 @@ class Dandelion:
             if len(vdjlengths) > 0:
                 self.update_metadata(
                     retrieve=vdjlengths,
-                    retrieve_mode="split and sum",
+                    retrieve_mode="split and average",
                     **kwargs,
                 )
             if len(seqinfo) > 0:
@@ -1336,7 +1336,7 @@ class Dandelion:
             if len(vdjlengths) > 0:
                 self.update_metadata(
                     retrieve=vdjlengths,
-                    retrieve_mode="split and sum",
+                    retrieve_mode="split and average",
                     **kwargs,
                 )
         if option == "mutations and cdr3 lengths":
@@ -1352,7 +1352,7 @@ class Dandelion:
             if len(vdjlengths) > 0:
                 self.update_metadata(
                     retrieve=vdjlengths,
-                    retrieve_mode="split and sum",
+                    retrieve_mode="split and average",
                     **kwargs,
                 )
 


### PR DESCRIPTION
now for cdr3 lengths, np1 lengths etc, these will be averaged instead of summed as the default.

this can be overwritten like so:

```
vdjlengths = [
            "junction_length",
            "junction_aa_length",
            "np1_length",
            "np2_length",
        ]
vdj.update_metadata(retrieve=vdjlengths, retrieve_mode="split and sum")
```