### PR TITLE
Make ntop check more consistent

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -21,7 +21,7 @@ def test_generic_check(airr_generic):
     tmp2 = ddl.pp.check_contigs(tmp, productive_only=False, library_type="ig")
     assert tmp2.metadata.shape[0] == 25
     assert tmp2.data.shape[0] != tmp.data.shape[0]
-    assert tmp2.data.shape[0] == 65
+    assert tmp2.data.shape[0] == 58  # 65
 
     tmp2 = ddl.pp.check_contigs(tmp)
     assert tmp2.metadata.shape[0] == 43
@@ -47,7 +47,7 @@ def test_check_keep_extra(airr_generic):
     assert tmp3.metadata.shape[0] == 43
     assert tmp2.data.shape[0] != tmp.data.shape[0]
     assert tmp3.data.shape[0] == tmp.data.shape[0]
-    assert tmp3.data.extra.value_counts()["T"] == 14
+    assert tmp3.data.extra.value_counts()["T"] == 16  # 14
 
 
 @pytest.mark.usefixtures("airr_generic")
@@ -62,5 +62,5 @@ def test_check_remove_ambiguous(airr_generic):
     assert tmp2.data.shape[0] != tmp.data.shape[0]
     assert tmp3.data.shape[0] != tmp2.data.shape[0]
     assert tmp2.data.ambiguous.value_counts()["T"] == 37
-    assert tmp2.data.ambiguous.value_counts()["F"] == 79
+    assert tmp2.data.ambiguous.value_counts()["F"] == 77  # 79
     assert all(tmp3.data.ambiguous == "F")

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -100,8 +100,8 @@ def test_slice_data_with_graph(airr_generic):
     assert vdj2.data.shape[0] == 114  # 116
     assert vdj2.metadata.shape[0] == 43
     vdj2 = vdj[vdj.metadata["productive_VDJ"] == "T"]
-    assert vdj2.data.shape[0] == 50
-    assert vdj2.metadata.shape[0] == 22
+    assert vdj2.data.shape[0] == 60  # 50
+    assert vdj2.metadata.shape[0] == 27  # 22
     vdj2 = vdj[
         vdj.metadata_names.isin(
             [
@@ -113,7 +113,7 @@ def test_slice_data_with_graph(airr_generic):
             ]
         )
     ]
-    assert vdj2.data.shape[0] == 19
+    assert vdj2.data.shape[0] == 17  # 19
     assert vdj2.metadata.shape[0] == 5
     assert len(vdj2.layout[0]) == 5
     assert len(vdj2.layout[1]) == 5
@@ -155,7 +155,7 @@ def test_slice_data_with_graph(airr_generic):
             ]
         )
     ]
-    assert vdj2.data.shape[0] == 30
+    assert vdj2.data.shape[0] == 28  # 30
     assert vdj2.metadata.shape[0] == 12
     assert len(vdj2.layout[0]) == 12
     # assert len(vdj2.layout[1]) == 4

--- a/tests/test_load_data.py
+++ b/tests/test_load_data.py
@@ -97,7 +97,7 @@ def test_slice_data_with_graph(airr_generic):
     ddl.tl.find_clones(vdj)
     ddl.tl.generate_network(vdj, key="junction", layout_method="mod_fr")
     vdj2 = vdj[vdj.data["productive"] == "T"]
-    assert vdj2.data.shape[0] == 116
+    assert vdj2.data.shape[0] == 114  # 116
     assert vdj2.metadata.shape[0] == 43
     vdj2 = vdj[vdj.metadata["productive_VDJ"] == "T"]
     assert vdj2.data.shape[0] == 50


### PR DESCRIPTION
For `check_contigs` ntop was only working for productive contigs and this leads to inconsistent behaviour when trying to filter to just 1 main contig pair. so now the check is applied to both productive and non-productive contigs + adding a step after the checks to prioritise productive contigs with the highest UMI.